### PR TITLE
Supporting empty text/speak in the Activity due to MCS client

### DIFF
--- a/libraries/Core/microsoft-agents-core/microsoft/agents/core/models/activity.py
+++ b/libraries/Core/microsoft-agents-core/microsoft/agents/core/models/activity.py
@@ -139,8 +139,8 @@ class Activity(AgentsModel):
     topic_name: NonEmptyString = None
     history_disclosed: bool = None
     locale: NonEmptyString = None
-    text: NonEmptyString = None
-    speak: NonEmptyString = None
+    text: str = None
+    speak: str = None
     input_hint: NonEmptyString = None
     summary: NonEmptyString = None
     suggested_actions: SuggestedActions = None


### PR DESCRIPTION
This pull request updates the `Activity` class in the `microsoft/agents/core/models/activity.py` file to improve type flexibility by changing the types of two attributes. 

Type adjustments for `Activity` class:

* [`libraries/Core/microsoft-agents-core/microsoft/agents/core/models/activity.py`](diffhunk://#diff-780ec4c018896aafa892474544eaecc1dfa43d13d91156015e5a877a6c33fec5L142-R143): Updated the `text` and `speak` attributes in the `Activity` class to use the more general `str` type instead of `NonEmptyString`, allowing for greater flexibility in handling these fields.

Fixes #51 