### PR TITLE
Deserializing some CopSt responses provide an empty string causing parsing error. May require further investigation.

### DIFF
--- a/libraries/Client/microsoft-agents-copilotstudio-client/microsoft/agents/copilotstudio/client/copilot_client.py
+++ b/libraries/Client/microsoft-agents-copilotstudio-client/microsoft/agents/copilotstudio/client/copilot_client.py
@@ -47,7 +47,7 @@ class CopilotClient:
                                 self._current_conversation_id = activity.conversation.id
                             yield activity
                         except Exception as e:
-                            print(f"Error parsing activity: {e} - {activity_data}")  
+                            print(f"Error parsing activity: {e} - {activity_data}")
 
     async def start_conversation(
         self, emit_start_conversation_event: bool = True


### PR DESCRIPTION
While testing `copilot_studio_client_sample` with a fresh/empty CopilotStudio agent, I got a parsing error due to an empty string in some of the fields in `activity_data`. The try-catch works as a workaround but further research may be required to get to the root cause.

This is the raw error:

```
Exception has occurred: ValidationError
1 validation error for Activity
text
  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/string_too_short
  File "C:\Repos\test\test.py", line 178, in start_service self._print_activity(activity)
  File "C:\Repos\test\test.py", line 227, in <module>
    loop.run_until_complete(ChatConsoleService(create_mcs_client(mcs_connection_settings)).start_service())
pydantic_core._pydantic_core.ValidationError: 1 validation error for Activity
text
  String should have at least 1 character [type=string_too_short, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/string_too_short
```