### PR TITLE
Added default values for fields that are sometimes missing when communicating with MCS

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft/agents/activity/channel_account.py
+++ b/libraries/microsoft-agents-activity/microsoft/agents/activity/channel_account.py
@@ -22,7 +22,7 @@ class ChannelAccount(AgentsModel):
 
     model_config = ConfigDict(extra="allow")
 
-    id: NonEmptyString
+    id: NonEmptyString = None
     name: str = None
     aad_object_id: NonEmptyString = None
     role: NonEmptyString = None

--- a/libraries/microsoft-agents-activity/microsoft/agents/activity/conversation_reference.py
+++ b/libraries/microsoft-agents-activity/microsoft/agents/activity/conversation_reference.py
@@ -42,7 +42,7 @@ class ConversationReference(AgentsModel):
     conversation: ConversationAccount
     channel_id: NonEmptyString
     locale: Optional[NonEmptyString] = None
-    service_url: NonEmptyString
+    service_url: NonEmptyString = None
 
     def get_continuation_activity(self) -> "Activity":  # type: ignore
         from .activity import Activity


### PR DESCRIPTION
ConversationReference.service_url and ChannelAccount.id are sometimes missing when receiving an Activity from MCS. This change will support this.