### PR TITLE
Users/axsuarez/enable no config (#88)

### DIFF
--- a/libraries/microsoft-agents-hosting-aiohttp/microsoft/agents/hosting/aiohttp/cloud_adapter.py
+++ b/libraries/microsoft-agents-hosting-aiohttp/microsoft/agents/hosting/aiohttp/cloud_adapter.py
@@ -36,7 +36,7 @@ class CloudAdapter(ChannelServiceAdapter, AgentHttpAdapter):
     def __init__(
         self,
         *,
-        connection_manager: Connections,
+        connection_manager: Connections = None,
         channel_service_client_factory: ChannelServiceClientFactoryBase = None,
     ):
         """

--- a/libraries/microsoft-agents-hosting-aiohttp/microsoft/agents/hosting/aiohttp/jwt_authorization_middleware.py
+++ b/libraries/microsoft-agents-hosting-aiohttp/microsoft/agents/hosting/aiohttp/jwt_authorization_middleware.py
@@ -22,7 +22,7 @@ async def jwt_authorization_middleware(request: Request, handler):
             print(f"JWT validation error: {e}")
             return json_response({"error": str(e)}, status=401)
     else:
-        if not auth_config.CLIENT_ID:
+        if not auth_config or not auth_config.CLIENT_ID:
             # TODO: Refine anonymous strategy
             request["claims_identity"] = token_validator.get_anonymous_claims()
         else:

--- a/libraries/microsoft-agents-hosting-core/microsoft/agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft/agents/hosting/core/app/agent_application.py
@@ -147,24 +147,17 @@ class AgentApplication(Agent, Generic[StateT]):
         if authorization:
             self._auth = authorization
         else:
-            if not connection_manager:
-                logger.error(
-                    "ApplicationOptions.authorization requires a Connections instance.",
-                    stack_info=True,
-                )
-                raise ApplicationError(
-                    """
-                    The `AgentApplication` requires a `Connections` instance to be passed as the
-                    `connection_manager` parameter.
-                    """
-                )
-            else:
-                self._auth = Authorization(
-                    storage=self._options.storage,
-                    connection_manager=connection_manager,
-                    handlers=options.authorization_handlers,
-                    **configuration,
-                )
+            auth_options = {
+                key: value
+                for key, value in configuration.items()
+                if key not in ["storage", "connection_manager", "handlers"]
+            }
+            self._auth = Authorization(
+                storage=self._options.storage,
+                connection_manager=connection_manager,
+                handlers=options.authorization_handlers,
+                **auth_options,
+            )
 
     @property
     def adapter(self) -> ChannelServiceAdapter:

--- a/libraries/microsoft-agents-hosting-core/microsoft/agents/hosting/core/app/oauth/authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft/agents/hosting/core/app/oauth/authorization.py
@@ -245,6 +245,10 @@ class Authorization:
         Returns:
             The new token response.
         """
+        if not self._connection_manager:
+            logger.error("Connection manager is not configured", stack_info=True)
+            raise ValueError("Connection manager is not configured")
+
         auth_handler = self.resolver_handler(handler_id)
         if auth_handler.flow is None:
             logger.error("OAuth flow is not configured for the auth handler")

--- a/test_samples/app_style/emtpy_agent.py
+++ b/test_samples/app_style/emtpy_agent.py
@@ -1,92 +1,40 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import re
-import sys
-import traceback
-from aiohttp.web import Application, Request, Response, run_app
-from dotenv import load_dotenv
-
-from os import environ, path
-from microsoft.agents.hosting.aiohttp import (
-    CloudAdapter,
-    jwt_authorization_middleware,
-    start_agent_process,
-)
 from microsoft.agents.hosting.core import (
-    Authorization,
     AgentApplication,
     TurnState,
     TurnContext,
     MemoryStorage,
 )
-from microsoft.agents.authentication.msal import MsalConnectionManager
-from microsoft.agents.activity import load_configuration_from_env
+from microsoft.agents.hosting.aiohttp import CloudAdapter
 
-load_dotenv(path.join(path.dirname(__file__), ".env"))
-
-agents_sdk_config = load_configuration_from_env(environ)
-
-STORAGE = MemoryStorage()
-CONNECTION_MANAGER = MsalConnectionManager(**agents_sdk_config)
-ADAPTER = CloudAdapter(connection_manager=CONNECTION_MANAGER)
-AUTHORIZATION = Authorization(STORAGE, CONNECTION_MANAGER, **agents_sdk_config)
+from shared import start_server
 
 AGENT_APP = AgentApplication[TurnState](
-    storage=STORAGE, adapter=ADAPTER, authorization=AUTHORIZATION, **agents_sdk_config
+    storage=MemoryStorage(), adapter=CloudAdapter()
 )
 
 
-@AGENT_APP.conversation_update("membersAdded")
-async def on_members_added(context: TurnContext, _state: TurnState):
+async def _help(context: TurnContext, _state: TurnState):
     await context.send_activity(
-        "Welcome to the empty agent! "
-        "This agent is designed to be a starting point for your own agent development."
+        "Welcome to the Echo Agent sample 🚀. "
+        "Type /help for help or send a message to see the echo feature in action."
     )
-    return True
 
 
-@AGENT_APP.message(re.compile(r"^hello$"))
-async def on_hello(context: TurnContext, _state: TurnState):
-    await context.send_activity("Hello!")
+AGENT_APP.conversation_update("membersAdded")(_help)
+
+AGENT_APP.message("/help")(_help)
 
 
 @AGENT_APP.activity("message")
-async def on_message(context: TurnContext, _state: TurnState):
+async def on_message(context: TurnContext, _):
     await context.send_activity(f"you said: {context.activity.text}")
 
 
-@AGENT_APP.error
-async def on_error(context: TurnContext, error: Exception):
-    # This check writes out errors to console log .vs. app insights.
-    # NOTE: In production environment, you should consider logging this to Azure
-    #       application insights.
-    print(f"\n [on_turn_error] unhandled error: {error}", file=sys.stderr)
-    traceback.print_exc()
-
-    # Send a message to the user
-    await context.send_activity("The bot encountered an error or bug.")
-
-
-# Listen for incoming requests on /api/messages
-async def messages(req: Request) -> Response:
-    agent: AgentApplication = req.app["agent_app"]
-    adapter: CloudAdapter = req.app["adapter"]
-    return await start_agent_process(
-        req,
-        agent,
-        adapter,
-    )
-
-
-APP = Application(middlewares=[jwt_authorization_middleware])
-APP.router.add_post("/api/messages", messages)
-APP["agent_configuration"] = CONFIG
-APP["agent_app"] = AGENT_APP
-APP["adapter"] = ADAPTER
-
 if __name__ == "__main__":
     try:
-        run_app(APP, host="localhost", port=CONFIG.PORT)
+        start_server(AGENT_APP, None)
     except Exception as error:
         raise error

--- a/test_samples/app_style/shared/start_server.py
+++ b/test_samples/app_style/shared/start_server.py
@@ -22,6 +22,7 @@ def start_server(
 
     APP = Application(middlewares=[jwt_authorization_middleware])
     APP.router.add_post("/api/messages", entry_point)
+    APP.router.add_get("/api/messages", lambda _: Response(status=200))
     APP["agent_configuration"] = auth_configuration
     APP["agent_app"] = agent_application
     APP["adapter"] = agent_application.adapter


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the agent hosting libraries and test samples. The most significant changes include relaxing requirements for the `connection_manager` parameter, improving error handling and configuration logic, and simplifying the sample agent application for easier use and clarity.

**Core library changes:**

* Relaxed the requirement for the `connection_manager` parameter in the `CloudAdapter` constructor by making it optional (`None` by default).
* Improved error handling in the `Authorization` and OAuth flow by explicitly checking for missing `connection_manager` and raising clear errors if it's not configured. [[1]](diffhunk://#diff-bc903ec8203f314cd7e0b97df82c180a09365e1f3cc15e9ed649a895bfab58bfL150-R159) [[2]](diffhunk://#diff-f5dbcbc7405d1140a8a59fee0fa4b707d5635d6b0333c274f8dbb11da1908f75R248-R251)
* Updated the construction of the `Authorization` object to filter out unrelated configuration keys, preventing accidental passing of unnecessary parameters.
* Enhanced JWT middleware to handle missing `auth_config` gracefully, avoiding potential runtime errors.

**Test sample and server changes:**

* Refactored the `emtpy_agent.py` sample to remove unnecessary imports and configuration, streamline setup, and use the new simplified server start logic from the shared module. The sample now provides a minimal echo agent with a `/help` command.
* Added a GET endpoint for `/api/messages` in the shared server setup to support health checks or simple connectivity tests.