### PR TITLE
Typo. using this commit to test nightly rules (change in last 24hrs)

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft/agents/hosting/core/oauth_flow.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft/agents/hosting/core/oauth_flow.py
@@ -152,7 +152,7 @@ class OAuthFlow:
             ],
         )
 
-        signing_resource = (
+        sign_in_resource = (
             await self.user_token_client.agent_sign_in.get_sign_in_resource(
                 state=token_exchange_state.get_encoded_state(),
             )
@@ -167,12 +167,12 @@ class OAuthFlow:
                     CardAction(
                         title=self.messages_configuration.get("button_text", "Sign in"),
                         type=ActionTypes.signin,
-                        value=signing_resource.sign_in_link,
+                        value=sign_in_resource.sign_in_link,
                         channel_data=None,
                     )
                 ],
-                token_exchange_resource=signing_resource.token_exchange_resource,
-                token_post_resource=signing_resource.token_post_resource,
+                token_exchange_resource=sign_in_resource.token_exchange_resource,
+                token_post_resource=sign_in_resource.token_post_resource,
             )
         )
 


### PR DESCRIPTION
This pull request makes a minor but important change to variable naming in the `begin_flow` method of `oauth_flow.py` to improve code clarity and consistency.

- Refactored variable name from `signing_resource` to `sign_in_resource` throughout the `begin_flow` method to better reflect its purpose and usage. [[1]](diffhunk://#diff-f08d0aae2406c5f521951ba886debf7b64295872364665210c37205d107fd37fL155-R155) [[2]](diffhunk://#diff-f08d0aae2406c5f521951ba886debf7b64295872364665210c37205d107fd37fL170-R175)