### PR TITLE
Added support for targeted messages

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft/agents/activity/__init__.py
+++ b/libraries/microsoft-agents-activity/microsoft/agents/activity/__init__.py
@@ -2,6 +2,7 @@ from .agents_model import AgentsModel
 from .action_types import ActionTypes
 from .activity import Activity
 from .activity_event_names import ActivityEventNames
+from .activity_treatment import ActivityTreatment, ActivityTreatmentType
 from .activity_types import ActivityTypes
 from .adaptive_card_invoke_action import AdaptiveCardInvokeAction
 from .adaptive_card_invoke_response import AdaptiveCardInvokeResponse
@@ -24,7 +25,7 @@ from .conversation_reference import ConversationReference
 from .conversation_resource_response import ConversationResourceResponse
 from .conversations_result import ConversationsResult
 from .expected_replies import ExpectedReplies
-from .entity import Entity
+from .entity import Entity, EntityTypes
 from .ai_entity import (
     AIEntity,
     ClientCitation,

--- a/libraries/microsoft-agents-activity/microsoft/agents/activity/activity.py
+++ b/libraries/microsoft-agents-activity/microsoft/agents/activity/activity.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from pydantic import Field, SerializeAsAny
 from .activity_types import ActivityTypes
+from .activity_treatment import ActivityTreatment
 from .channel_account import ChannelAccount
 from .conversation_account import ConversationAccount
 from .mention import Mention
@@ -532,8 +533,15 @@ class Activity(AgentsModel):
             This method is defined on the :class:`Activity` class, but is only intended for use with a message activity,
             where the activity Activity.Type is set to ActivityTypes.Message.
         """
-        _list = self.entities
-        return [x for x in _list if str(x.type).lower() == "mention"]
+        return [x for x in self.entities if str(x.type).lower() == "mention"]
+
+    def get_activity_treatments(self) -> list[ActivityTreatment]:
+        """
+        Resolves the activity treatments from the entities of this activity.
+
+        :returns: The array of activity treatments; or an empty array, if none are found.
+        """
+        return [x for x in self.entities if str(x.type).lower() == "activitytreatment"]
 
     def get_reply_conversation_reference(
         self, reply: ResourceResponse

--- a/libraries/microsoft-agents-activity/microsoft/agents/activity/activity_treatment.py
+++ b/libraries/microsoft-agents-activity/microsoft/agents/activity/activity_treatment.py
@@ -1,0 +1,27 @@
+from enum import Enum
+
+from .entity import Entity, EntityTypes
+from ._type_aliases import NonEmptyString
+
+
+class ActivityTreatmentType(str, Enum):
+    """Activity treatment types
+
+    TARGETED: only the recipient should be able to see the message even if the activity
+        is being sent to a group of people.
+    """
+
+    TARGETED = "targeted"
+
+
+class ActivityTreatment(Entity):
+    """Activity treatment information (entity type: "activitytreatment").
+
+    :param treatment: The treatment type
+    :type treatment: ~microsoft.agents.activity.ActivityTreatmentType
+    :param type: Type of this entity (RFC 3987 IRI)
+    :type type: NonEmptyString
+    """
+
+    treatment: ActivityTreatmentType = None
+    type: NonEmptyString = EntityTypes.ACTIVITY_TREATMENT

--- a/libraries/microsoft-agents-activity/microsoft/agents/activity/entity.py
+++ b/libraries/microsoft-agents-activity/microsoft/agents/activity/entity.py
@@ -1,9 +1,24 @@
+from __future__ import annotations
+
 from typing import Any, Optional
 
 from pydantic import model_serializer, model_validator
 from .agents_model import AgentsModel, ConfigDict
 from pydantic.alias_generators import to_camel, to_snake
 from ._type_aliases import NonEmptyString
+
+from enum import Enum
+
+
+class EntityTypes:
+
+    MENTION = "mention"
+    ACTIVITY_TREATMENT = "activitytreatment"
+
+    # ENTITY_MAP = {
+    #     EntityTypes.MENTION: Mention,
+    #     EntityTypes.ACTIVITY_TREATMENT: ActivityTreatment,
+    # }
 
 
 class Entity(AgentsModel):
@@ -36,3 +51,7 @@ class Entity(AgentsModel):
                 new_data[to_camel(k)] = v
             return new_data
         return {k: v for k, v in self}
+
+    # @classmethod
+    # def deserialize_entity(cls, entity: Entity) -> Entity:
+    #     return EntityTypes.ENTITY_MAP[entity.type](entity.model_dump())

--- a/libraries/microsoft-agents-activity/microsoft/agents/activity/mention.py
+++ b/libraries/microsoft-agents-activity/microsoft/agents/activity/mention.py
@@ -1,5 +1,5 @@
 from .channel_account import ChannelAccount
-from .entity import Entity
+from .entity import Entity, EntityTypes
 from ._type_aliases import NonEmptyString
 
 
@@ -16,4 +16,4 @@ class Mention(Entity):
 
     mentioned: ChannelAccount = None
     text: NonEmptyString = None
-    type: NonEmptyString = None
+    type: NonEmptyString = EntityTypes.MENTION

--- a/libraries/microsoft-agents-activity/tests/test_activity.py
+++ b/libraries/microsoft-agents-activity/tests/test_activity.py
@@ -1,0 +1,59 @@
+import pytest
+
+from microsoft.agents.activity import (
+    Activity,
+    ActivityTreatment,
+    ActivityTreatmentType,
+    Entity,
+    EntityTypes,
+    Mention,
+)
+
+
+class TestActivityGetEntities:
+
+    @pytest.fixture
+    def activity(self):
+        return Activity(
+            type="message",
+            entities=[
+                ActivityTreatment(treatment=ActivityTreatmentType.TARGETED),
+                Entity(
+                    type=EntityTypes.ACTIVITY_TREATMENT,
+                    treatment=ActivityTreatmentType.TARGETED,
+                ),
+                Mention(type=EntityTypes.MENTION, text="Hello"),
+                Entity(type=EntityTypes.MENTION),
+                Entity(type=EntityTypes.ACTIVITY_TREATMENT, treatment=None),
+            ],
+        )
+
+    def test_activity_get_mentions(self, activity):
+        expected = [
+            Mention(type=EntityTypes.MENTION, text="Hello"),
+            Entity(type=EntityTypes.MENTION),
+        ]
+        ret = activity.get_mentions()
+        assert activity.get_mentions() == expected
+        assert ret[0].text == "Hello"
+        assert ret[0].type == EntityTypes.MENTION
+        assert not hasattr(ret[1], "text")
+        assert ret[1].type == EntityTypes.MENTION
+
+    def test_activity_get_activity_treatments(self, activity):
+        expected = [
+            ActivityTreatment(treatment=ActivityTreatmentType.TARGETED),
+            Entity(
+                type=EntityTypes.ACTIVITY_TREATMENT,
+                treatment=ActivityTreatmentType.TARGETED,
+            ),
+            Entity(type=EntityTypes.ACTIVITY_TREATMENT, treatment=None),
+        ]
+        ret = activity.get_activity_treatments()
+        assert ret == expected
+        assert ret[0].treatment == ActivityTreatmentType.TARGETED
+        assert ret[0].type == EntityTypes.ACTIVITY_TREATMENT
+        assert ret[1].treatment == ActivityTreatmentType.TARGETED
+        assert ret[1].type == EntityTypes.ACTIVITY_TREATMENT
+        assert ret[2].treatment is None
+        assert ret[2].type == EntityTypes.ACTIVITY_TREATMENT

--- a/libraries/microsoft-agents-activity/tests/test_entities.py
+++ b/libraries/microsoft-agents-activity/tests/test_entities.py
@@ -1,0 +1,75 @@
+import pytest
+
+from microsoft.agents.activity import (
+    Entity,
+    EntityTypes,
+    Mention,
+    ActivityTreatment,
+    ActivityTreatmentType,
+    ChannelAccount,
+)
+
+
+class TestSerialization:
+
+    def test_mention_serializer(self):
+        initial_mention = Mention(text="Hello", mentioned=ChannelAccount(id="abc"))
+        initial_mention_dict = initial_mention.model_dump(
+            mode="json", exclude_unset=True, by_alias=True
+        )
+        mention = Mention.model_validate(initial_mention_dict)
+
+        assert initial_mention_dict == {
+            "text": "Hello",
+            "mentioned": {"id": "abc"},
+            "type": EntityTypes.MENTION,
+        }
+        assert mention == initial_mention
+
+    def test_mention_serializer_as_entity(self):
+        initial_mention = Entity(
+            text="Hello", mentioned=ChannelAccount(id="abc"), type=EntityTypes.MENTION
+        )
+        initial_mention_dict = initial_mention.model_dump(
+            mode="json", exclude_unset=True, by_alias=True
+        )
+        mention = Mention.model_validate(initial_mention_dict)
+
+        assert initial_mention_dict == {
+            "text": "Hello",
+            "mentioned": {"id": "abc"},
+            "type": EntityTypes.MENTION,
+        }
+        assert mention.type == initial_mention.type
+        assert mention.text == initial_mention.text
+        assert mention.mentioned == initial_mention.mentioned
+
+    def test_activity_treatment_serializer(self):
+        initial_treatment = ActivityTreatment(treatment=ActivityTreatmentType.TARGETED)
+        initial_treatment_dict = initial_treatment.model_dump(
+            mode="json", exclude_unset=True, by_alias=True
+        )
+        treatment = ActivityTreatment.model_validate(initial_treatment_dict)
+
+        assert initial_treatment_dict == {
+            "treatment": ActivityTreatmentType.TARGETED,
+            "type": EntityTypes.ACTIVITY_TREATMENT,
+        }
+        assert treatment == initial_treatment
+
+    def test_activity_treatment_serializer_as_entity(self):
+        initial_treatment = Entity(
+            treatment=ActivityTreatmentType.TARGETED,
+            type=EntityTypes.ACTIVITY_TREATMENT,
+        )
+        initial_treatment_dict = initial_treatment.model_dump(
+            mode="json", exclude_unset=True, by_alias=True
+        )
+        treatment = ActivityTreatment.model_validate(initial_treatment_dict)
+
+        assert initial_treatment_dict == {
+            "treatment": ActivityTreatmentType.TARGETED,
+            "type": EntityTypes.ACTIVITY_TREATMENT,
+        }
+        assert treatment.type == initial_treatment.type
+        assert treatment.treatment == initial_treatment.treatment


### PR DESCRIPTION
This pull request adds support for "activity treatment" entities to the Microsoft Agents Activity library, improves the handling and serialization of entity types, and introduces some tests for these features. The most important changes are grouped below:

### Activity Treatment Entity Support

* Introduced the `ActivityTreatment` entity and its type enum `ActivityTreatmentType`, allowing activities to specify treatment information such as targeted delivery. (`activity_treatment.py`, `__init__.py`) [[1]](diffhunk://#diff-ab96673ac6541a74c2fd48e1d62f27e27d2c91cdc1776cdced2defd15e346c58R1-R27) [[2]](diffhunk://#diff-d100ff6c2ff56b5d3d5ad67e104941e296cc878311d41a64d4ee86f7179989b1R5)
* Added the `get_activity_treatments` method to the `Activity` class to easily retrieve all activity treatment entities from an activity. (`activity.py`)

### Entity Type Improvements

* Added the `EntityTypes` class to centralize entity type string constants (e.g., "mention", "activitytreatment"), and updated entity classes to use these constants for type assignment. (`entity.py`, `mention.py`, `__init__.py`) [[1]](diffhunk://#diff-fc116548eb6a2f6bd63c50da0cc8256c6de3d46e89013f6c72c69fe5cfc51381R1-R22) [[2]](diffhunk://#diff-3b7cb4a46019f5f541bc70ad7e1ba1032b81d50521352b2e2da7601cedce020dL2-R2) [[3]](diffhunk://#diff-3b7cb4a46019f5f541bc70ad7e1ba1032b81d50521352b2e2da7601cedce020dL19-R19) [[4]](diffhunk://#diff-d100ff6c2ff56b5d3d5ad67e104941e296cc878311d41a64d4ee86f7179989b1L27-R28)
* Updated imports throughout the codebase to use the new `EntityTypes` class. (`__init__.py`, `activity.py`, `mention.py`) [[1]](diffhunk://#diff-d100ff6c2ff56b5d3d5ad67e104941e296cc878311d41a64d4ee86f7179989b1R5) [[2]](diffhunk://#diff-d100ff6c2ff56b5d3d5ad67e104941e296cc878311d41a64d4ee86f7179989b1L27-R28) [[3]](diffhunk://#diff-1fbda2dba4f6293f753f212836ea058ead1ef006de55acc2c37fee6e351d00ffR6) [[4]](diffhunk://#diff-3b7cb4a46019f5f541bc70ad7e1ba1032b81d50521352b2e2da7601cedce020dL2-R2)

### Testing and Serialization

* Added new tests for entity extraction methods (`get_mentions`, `get_activity_treatments`) and for serialization/deserialization of `Mention` and `ActivityTreatment` entities, ensuring correct handling and compatibility with generic `Entity` objects. (`test_activity.py`, `test_entities.py`) [[1]](diffhunk://#diff-4220e464fac54071fe7408e2419dafc8a001aee14da5a032617f3557aef42ecaR1-R59) [[2]](diffhunk://#diff-8d62fd92d87aef7510289c2dc898b9336365b35d4ae84606a335081ea436f9e6R1-R75)

These changes enhance the extensibility and reliability of the activity entity system, making it easier to work with new entity types and ensuring robust serialization and extraction logic.