### PR TITLE
[Cherry-pick] Setting flow state to COMPLETE when retrieving cached token (#112)

### DIFF
--- a/.azdo/ci-pr.yaml
+++ b/.azdo/ci-pr.yaml
@@ -1,6 +1,7 @@
 pr:
 - main
 - dev
+- release/*
 
 pool:
   vmImage: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   schedule:
     - cron: '22 7 * * 4'
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,9 +8,9 @@ permissions:
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   build:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/oauth/oauth_flow.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/oauth/oauth_flow.py
@@ -140,6 +140,7 @@ class OAuthFlow:
             self._flow_state.expiration = (
                 datetime.now().timestamp() + self._default_flow_duration
             )
+            self._flow_state.tag = FlowStateTag.COMPLETE
 
         return token_response
 

--- a/libraries/microsoft-agents-hosting-core/tests/test_oauth_flow.py
+++ b/libraries/microsoft-agents-hosting-core/tests/test_oauth_flow.py
@@ -137,6 +137,7 @@ class TestOAuthFlow(TestOAuthFlowUtils):
         flow = OAuthFlow(sample_flow_state, user_token_client)
         expected_final_flow_state = sample_flow_state
         expected_final_flow_state.user_token = RES_TOKEN
+        expected_final_flow_state.tag = FlowStateTag.COMPLETE
 
         # test
         token_response = await flow.get_user_token()
@@ -201,6 +202,7 @@ class TestOAuthFlow(TestOAuthFlowUtils):
         activity = mocker.Mock(spec=Activity)
         expected_flow_state = sample_flow_state
         expected_flow_state.user_token = RES_TOKEN
+        expected_flow_state.tag = FlowStateTag.COMPLETE
 
         # test
         response = await flow.begin_flow(activity)


### PR DESCRIPTION
* Fixed reference to Activity.add_ai_metadata

* Setting flow state to complete on get_token