### PR TITLE
adding pipeline trigger to pr against release branch

### DIFF
--- a/.azdo/ci-pr.yaml
+++ b/.azdo/ci-pr.yaml
@@ -1,6 +1,7 @@
 pr:
 - main
 - dev
+- release/*
 
 pool:
   vmImage: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   schedule:
     - cron: '22 7 * * 4'
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,9 +8,9 @@ permissions:
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/*" ]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates CI/CD configuration files to ensure that workflows and pipelines run not only on the `main` and `dev` branches but also on any branches matching the `release/*` pattern. This change improves automation coverage for release branches, helping catch issues earlier in the release process.

**CI/CD workflow coverage improvements:**

* [`.azdo/ci-pr.yaml`](diffhunk://#diff-50b28cd1647a6801f28c6abec92ffc548ebdd47848c528f5b9baf0791c47fd7cR4): Added `release/*` to the list of branches that trigger the Azure DevOps PR pipeline.
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L16-R18): Updated both `push` and `pull_request` triggers to include `release/*` branches for CodeQL analysis.
* [`.github/workflows/python-package.yml`](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L11-R13): Updated both `push` and `pull_request` triggers to include `release/*` branches for the Python package workflow.