### PR TITLE
Dedupe validation for exchange SSO

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/oauth/flow_state.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/oauth/flow_state.py
@@ -33,6 +33,7 @@ class FlowErrorTag(Enum):
     NONE = "none"
     MAGIC_FORMAT = "magic_format"
     MAGIC_CODE_INCORRECT = "magic_code_incorrect"
+    DUPLICATE_EXCHANGE = "duplicate_exchange"
     OTHER = "other"
 
 

--- a/tests/_common/storage/utils.py
+++ b/tests/_common/storage/utils.py
@@ -4,12 +4,9 @@ from copy import deepcopy
 from abc import ABC
 from typing import Any
 
-from microsoft_agents.hosting.core.storage import (
-    Storage,
-    StoreItem,
-    MemoryStorage
-)
+from microsoft_agents.hosting.core.storage import Storage, StoreItem, MemoryStorage
 from microsoft_agents.hosting.core.storage._type_aliases import JSON
+
 
 class MockStoreItem(StoreItem):
     """Test implementation of StoreItem for testing purposes"""


### PR DESCRIPTION
This pull request introduces a deduplication mechanism for OAuth token exchange requests to prevent replay attacks and duplicate processing. The main changes include tracking processed token exchange IDs, handling duplicate requests gracefully, and periodically clearing the registry to avoid unbounded growth. Comprehensive tests have been added to verify these behaviors.

### OAuth Token Exchange Deduplication

* Added a public registry (`token_exchange_id_registry`) to track processed token exchange IDs within the `OAuthFlow` class, preventing duplicate token exchanges. The registry is cleared lazily based on a configurable interval to avoid memory growth. [[1]](diffhunk://#diff-853282495b0c56d7392976952a3c34c953cca270304befc3c30f0566edadb7aeR108-R121) [[2]](diffhunk://#diff-853282495b0c56d7392976952a3c34c953cca270304befc3c30f0566edadb7aeR391-R407)
* Updated the token exchange flow to check for duplicate IDs and return a specific error tag (`FlowErrorTag.DUPLICATE_EXCHANGE`) if a replay is detected. [[1]](diffhunk://#diff-853282495b0c56d7392976952a3c34c953cca270304befc3c30f0566edadb7aeL249-R283) [[2]](diffhunk://#diff-853282495b0c56d7392976952a3c34c953cca270304befc3c30f0566edadb7aeR297-R314) [[3]](diffhunk://#diff-9a070194b12647dd949e54dbcdfdc66c2d98d7a2f46974a7231ba21dad9269cdR36) [[4]](diffhunk://#diff-853282495b0c56d7392976952a3c34c953cca270304befc3c30f0566edadb7aeL291-R346)

### Testing Improvements

* Added new tests to ensure replayed token exchange requests are ignored and that the registry clears after the configured interval, allowing previously processed IDs to be accepted again.

### Minor Code Quality Improvements

* Minor formatting and import cleanups in test utility files (`utils.py`) and test classes. [[1]](diffhunk://#diff-322dcc121edecc8ec36ae861a93845bf862fbfcd8520d7004680b95506c5c0f7L7-R10) [[2]](diffhunk://#diff-a22f0c4e1eb9eb5cefb05742ba23c1ec39a978603efca7e62620fd7628a122a4L28) [[3]](diffhunk://#diff-a22f0c4e1eb9eb5cefb05742ba23c1ec39a978603efca7e62620fd7628a122a4L107)