### PR TITLE
Remove "delay" activity as an implied activity. Fixes #11

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/channel_service_adapter.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/channel_service_adapter.py
@@ -66,10 +66,7 @@ class ChannelServiceAdapter(ChannelAdapter, ABC):
 
             response = ResourceResponse()
 
-            if activity.type == "delay":
-                delay_time = int((activity.value or 1000) / 1000)
-                await sleep(delay_time)
-            elif activity.type == ActivityTypes.invoke_response:
+            if activity.type == ActivityTypes.invoke_response:
                 context.turn_state[self.INVOKE_RESPONSE_KEY] = activity
             elif (
                 activity.type == ActivityTypes.trace


### PR DESCRIPTION
Fixes #11 

This PR simply removed the check on the "delay" type (and the resulting sleep), as supporting that is against the spec. If someone want to implement this manually in their application code, such a delay should still be applicable. 

If I recall correctly, the history of this was to avoid older implementations sending messages too quickly and being received out of order. 

The C# version of this PR is found here:
https://github.com/microsoft/Agents-for-net/pull/240

Same approach taken in both languages. 
