### PR TITLE
Refactor testing functions to use correct naming scheme

### DIFF
--- a/tests/hosting_core/_oauth/test_oauth_flow.py
+++ b/tests/hosting_core/_oauth/test_oauth_flow.py
@@ -25,7 +25,7 @@ DEFAULTS = TEST_DEFAULTS()
 FLOW_DATA = TEST_FLOW_DATA()
 
 
-def testing_Activity(
+def create_testing_Activity(
     mocker,
     type=ActivityTypes.message,
     name="a",
@@ -53,7 +53,7 @@ def testing_Activity(
 class TestUtils(FlowStateFixtures):
     def setup_method(self):
         self.UserTokenClient = mock_UserTokenClient
-        self.Activity = testing_Activity
+        self.Activity = create_testing_Activity
 
     @pytest.fixture
     def user_token_client(self, mocker):

--- a/tests/hosting_core/app/_oauth/_common.py
+++ b/tests/hosting_core/app/_oauth/_common.py
@@ -8,7 +8,7 @@ from tests._common.testing_objects import mock_UserTokenClient
 DEFAULTS = TEST_DEFAULTS()
 
 
-def testing_Activity():
+def create_testing_Activity():
     return Activity(
         type=ActivityTypes.message,
         channel_id=DEFAULTS.channel_id,
@@ -17,7 +17,7 @@ def testing_Activity():
     )
 
 
-def testing_TurnContext(
+def create_testing_TurnContext(
     mocker,
     channel_id=DEFAULTS.channel_id,
     user_id=DEFAULTS.user_id,
@@ -45,7 +45,7 @@ def testing_TurnContext(
     return turn_context
 
 
-def testing_TurnContext_magic(
+def create_testing_TurnContext_magic(
     mocker,
     channel_id=DEFAULTS.channel_id,
     user_id=DEFAULTS.user_id,

--- a/tests/hosting_core/app/_oauth/_handlers/test_agentic_user_authorization.py
+++ b/tests/hosting_core/app/_oauth/_handlers/test_agentic_user_authorization.py
@@ -18,7 +18,7 @@ from tests._common.data import TEST_DEFAULTS, TEST_AGENTIC_ENV_DICT
 from tests._common.mock_utils import mock_class
 
 from .._common import (
-    testing_TurnContext_magic,
+    create_testing_TurnContext_magic,
 )
 
 DEFAULTS = TEST_DEFAULTS()
@@ -27,7 +27,7 @@ AGENTIC_ENV_DICT = TEST_AGENTIC_ENV_DICT()
 
 class TestUtils:
     def setup_method(self, mocker):
-        self.TurnContext = testing_TurnContext_magic
+        self.TurnContext = create_testing_TurnContext_magic
 
     @pytest.fixture
     def storage(self):
@@ -78,7 +78,6 @@ class TestUtils:
 
 
 class TestAgenticUserAuthorization(TestUtils):
-
     @pytest.mark.asyncio
     async def test_get_agentic_instance_token_not_agentic(
         self, mocker, non_agentic_role, agentic_auth

--- a/tests/hosting_core/app/_oauth/_handlers/test_user_authorization.py
+++ b/tests/hosting_core/app/_oauth/_handlers/test_user_authorization.py
@@ -49,7 +49,7 @@ class MyUserAuthorization(_UserAuthorization):
         pass
 
 
-def testing_TurnContext(
+def create_testing_TurnContext(
     mocker,
     channel_id=DEFAULTS.channel_id,
     user_id=DEFAULTS.user_id,
@@ -94,7 +94,7 @@ def mock_provider(mocker, exchange_token=None):
 
 class TestEnv(FlowStateFixtures):
     def setup_method(self):
-        self.TurnContext = testing_TurnContext
+        self.TurnContext = create_testing_TurnContext
 
     @pytest.fixture
     def context(self, mocker):

--- a/tests/hosting_core/app/_oauth/test_authorization.py
+++ b/tests/hosting_core/app/_oauth/test_authorization.py
@@ -44,7 +44,7 @@ from tests._common.testing_objects import (
     mock_class_Authorization,
 )
 
-from ._common import testing_TurnContext, testing_Activity
+from ._common import create_testing_TurnContext, create_testing_Activity
 
 DEFAULTS = TEST_DEFAULTS()
 FLOW_DATA = TEST_FLOW_DATA()
@@ -109,7 +109,7 @@ def copy_sign_in_state(state: _SignInState) -> _SignInState:
 
 class TestEnv(FlowStateFixtures):
     def setup_method(self):
-        self.TurnContext = testing_TurnContext
+        self.TurnContext = create_testing_TurnContext
         self.UserTokenClient = mock_UserTokenClient
         self.ConnectionManager = lambda mocker: MockConnectionManager()
 
@@ -119,7 +119,7 @@ class TestEnv(FlowStateFixtures):
 
     @pytest.fixture
     def activity(self):
-        return testing_Activity()
+        return create_testing_Activity()
 
     @pytest.fixture
     def baseline_storage(self):
@@ -191,7 +191,6 @@ class TestAuthorizationSetup(TestEnv):
 
 
 class TestAuthorizationUsage(TestEnv):
-
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "initial_turn_state, final_turn_state, initial_sign_in_state, auth_handler_id",


### PR DESCRIPTION
Fixes #163

A half dozen methods started with "test" that were not intended to be actual tests. PyTest tries to run these and generates warnings as their return types are not correct. This results in PyTest warnings that look like:

```
tests/hosting_core/_oauth/test_oauth_flow.py::testing_Activity
  D:\git\Agents-for-python\venv\Lib\site-packages\_pytest\python.py:161: PytestReturnNotNoneWarning: Test functions should return None, but tests/hosting_core/_oauth/test_oauth_flow.py::testing_Activity returned <class 'microsoft_agents.activity.activity.Activity'>.
...
```

Pytest picks up any function/class that starts with "test" as an actual test. The easiest fix for these is to simply rename them to NOT start with test. All functions encoutered as part of this are actually creating Mocks or similar testing entities for use by other tests.  