### PR TITLE
Add support for Python versions 3.12, 3.13, and 3.14 

### DIFF
--- a/.azdo/ci-pr.yaml
+++ b/.azdo/ci-pr.yaml
@@ -12,6 +12,12 @@ strategy:
       PYTHON_VERSION: '3.10'
     Python_3.11:
       PYTHON_VERSION: '3.11'
+    Python_3.12:
+      PYTHON_VERSION: '3.12'
+    Python_3.13:
+      PYTHON_VERSION: '3.13'
+    Python_3.14:
+      PYTHON_VERSION: '3.14'
 
 variables:
   - name: PackageVersion

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Additionally we provide a Copilot Studio Client, to interact with Agents created
 
 The packages should target Python 3.10 or greater, and can be used with modern Python package managers like pip, poetry, or conda.
 
-> Note: We recommend using Python 3.11 or later for optimal performance and compatibility with all features.
+> Note: We recommend using Python 3.11 or later for optimal performance and compatibility with all features. The SDK supports Python 3.10, 3.11, 3.12, 3.13, and 3.14.
 
 ### Debugging
 

--- a/libraries/microsoft-agents-activity/pyproject.toml
+++ b/libraries/microsoft-agents-activity/pyproject.toml
@@ -13,6 +13,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 dependencies = [

--- a/libraries/microsoft-agents-authentication-msal/pyproject.toml
+++ b/libraries/microsoft-agents-authentication-msal/pyproject.toml
@@ -13,6 +13,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 

--- a/libraries/microsoft-agents-authentication-msal/readme.md
+++ b/libraries/microsoft-agents-authentication-msal/readme.md
@@ -111,5 +111,14 @@ class AuthTypes(str, Enum):
 - 🐛 [Report Issues](https://github.com/microsoft/Agents-for-python/issues)
 
 # Sample Applications
+Explore working examples in the [Python samples repository](https://github.com/microsoft/Agents/tree/main/samples/python):
 
-w
+|Name|Description|README|
+|----|----|----|
+|Quickstart|Simplest agent|[Quickstart](https://github.com/microsoft/Agents/blob/main/samples/python/quickstart/README.md)|
+|Auto Sign In|Simple OAuth agent using Graph and GitHub|[auto-signin](https://github.com/microsoft/Agents/blob/main/samples/python/auto-signin/README.md)|
+|OBO Authorization|OBO flow to access a Copilot Studio Agent|[obo-authorization](https://github.com/microsoft/Agents/blob/main/samples/python/obo-authorization/README.md)|
+|Semantic Kernel Integration|A weather agent built with Semantic Kernel|[semantic-kernel-multiturn](https://github.com/microsoft/Agents/blob/main/samples/python/semantic-kernel-multiturn/README.md)|
+|Streaming Agent|Streams OpenAI responses|[azure-ai-streaming](https://github.com/microsoft/Agents/blob/main/samples/python/azureai-streaming/README.md)|
+|Copilot Studio Client|Console app to consume a Copilot Studio Agent|[copilotstudio-client](https://github.com/microsoft/Agents/blob/main/samples/python/copilotstudio-client/README.md)|
+|Cards Agent|Agent that uses rich cards to enhance conversation design |[cards](https://github.com/microsoft/Agents/blob/main/samples/python/cards/README.md)|

--- a/libraries/microsoft-agents-copilotstudio-client/pyproject.toml
+++ b/libraries/microsoft-agents-copilotstudio-client/pyproject.toml
@@ -13,6 +13,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 

--- a/libraries/microsoft-agents-copilotstudio-client/readme.md
+++ b/libraries/microsoft-agents-copilotstudio-client/readme.md
@@ -120,7 +120,7 @@ CUSTOM_POWER_PLATFORM_CLOUD=your-custom-cloud.com
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.10+ (supports 3.10, 3.11, 3.12, 3.13, 3.14)
 - Valid Azure AD app registration
 - Access to Microsoft Power Platform environment
 - Published Copilot Studio agent

--- a/libraries/microsoft-agents-hosting-aiohttp/pyproject.toml
+++ b/libraries/microsoft-agents-hosting-aiohttp/pyproject.toml
@@ -13,6 +13,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 

--- a/libraries/microsoft-agents-hosting-aiohttp/readme.md
+++ b/libraries/microsoft-agents-hosting-aiohttp/readme.md
@@ -92,7 +92,7 @@ async def on_error(context: TurnContext, error: Exception):
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.10+ (supports 3.10, 3.11, 3.12, 3.13, 3.14)
 - aiohttp 3.11.11+
 - Microsoft Agents hosting core library
 

--- a/libraries/microsoft-agents-hosting-core/pyproject.toml
+++ b/libraries/microsoft-agents-hosting-core/pyproject.toml
@@ -13,6 +13,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 

--- a/libraries/microsoft-agents-hosting-teams/pyproject.toml
+++ b/libraries/microsoft-agents-hosting-teams/pyproject.toml
@@ -13,6 +13,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 

--- a/libraries/microsoft-agents-storage-blob/pyproject.toml
+++ b/libraries/microsoft-agents-storage-blob/pyproject.toml
@@ -13,6 +13,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 

--- a/libraries/microsoft-agents-storage-cosmos/pyproject.toml
+++ b/libraries/microsoft-agents-storage-cosmos/pyproject.toml
@@ -13,6 +13,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,8 @@ python --version
 
 The virtual environment, by default, will created as a directory named `venv` that will be placed at the root of this project.
 
+> Note: The SDK supports Python 3.10, 3.11, 3.12, 3.13, and 3.14.
+
 ### Windows
 
 Powershell needs to be set to allow running of scripts. Do this by opening PowerShell in admin mode and running:

--- a/test_samples/README.md
+++ b/test_samples/README.md
@@ -1,6 +1,6 @@
 # Setting Up Virtual Environment and installing the SDK
 
-This guide explains how to create and activate a Python virtual environment using `venv` for Python versions 3.10 to 3.11.
+This guide explains how to create and activate a Python virtual environment using `venv` for Python versions 3.10 to 3.14.
 
 ## What is a Virtual Environment?
 
@@ -8,7 +8,7 @@ A virtual environment is an isolated Python environment that allows you to insta
 
 ## Prerequisites
 
-- Python 3.10, or 3.11 installed on your system
+- Python 3.10, 3.11, 3.12, 3.13, or 3.14 installed on your system
 - Basic knowledge of command line operations
 
 ## Creating a Virtual Environment

--- a/versioning/pyproject.toml
+++ b/versioning/pyproject.toml
@@ -15,3 +15,12 @@ dynamic = ["version"]
 description = "Helper project to calculate version"
 authors = [{name = "Microsoft Corporation"}]
 requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Operating System :: OS Independent",
+]


### PR DESCRIPTION
Fixes #170 

Add newer versions of Python into the build and test matrix. Update docs accordingly. We now call out support for Python 3.12, 3.13, and 3.14. Accord to the Python web site, we now align to the currently supported Python versions (3.10 - 3.14). 

<img width="1466" height="551" alt="image" src="https://github.com/user-attachments/assets/271340e2-a282-41f2-b912-0e49a4b4fea6" />

Note to reviewers: Once this PR is merged to main, I'll update the GitHub Branch Protection Rules to require the newer builds to pass on all PRs. 

<img width="2208" height="518" alt="image" src="https://github.com/user-attachments/assets/1e00b257-6f7b-4322-a71f-3cec74fd61cc" />

