### PR TITLE
Update conversation ID in copilot studio client when start_conversation is called

### DIFF
--- a/libraries/microsoft-agents-copilotstudio-client/microsoft_agents/copilotstudio/client/copilot_client.py
+++ b/libraries/microsoft-agents-copilotstudio-client/microsoft_agents/copilotstudio/client/copilot_client.py
@@ -40,7 +40,7 @@ class CopilotClient:
                 conversation_id_header = response.headers.get("x-ms-conversationid")
                 if conversation_id_header:
                     self._current_conversation_id = conversation_id_header
-                    
+
                 event_type = None
                 async for line in response.content:
                     if line.startswith(b"event:"):


### PR DESCRIPTION
Fix ### Details

1. Capture x-ms-conversationid from the start-conversation HTTP response when status is 200.
2. Persist it to _current_conversation_id so all later ask_question calls target the correct conversation