### PR TITLE
Adjusting default max conversation id length

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/connector/client/connector_client.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/connector/client/connector_client.py
@@ -124,7 +124,7 @@ class ConversationsOperations(ConversationsBase):
 
     def __init__(self, client: ClientSession, **kwargs):
         self.client = client
-        self._max_conversation_id_length = kwargs.get("max_conversation_id_length", 200)
+        self._max_conversation_id_length = kwargs.get("max_conversation_id_length", 150)
 
     def _normalize_conversation_id(self, conversation_id: str) -> str:
         return conversation_id[: self._max_conversation_id_length]


### PR DESCRIPTION
This pull request makes a minor configuration update to the `ConversationsOperations` class. The maximum allowed length for a conversation ID has been reduced from 200 to 150 characters to better align with system constraints.

* Reduced the default value of `_max_conversation_id_length` from 200 to 150 in the `ConversationsOperations` class (`connector_client.py`).