### PR TITLE
Fix for proactive experimental sample in WC

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/conversation_account.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/conversation_account.py
@@ -32,7 +32,7 @@ class ConversationAccount(AgentsModel):
     """
 
     is_group: Optional[bool] = None
-    conversation_type: NonEmptyString = None
+    conversation_type: Optional[NonEmptyString] = None
     id: NonEmptyString
     name: Optional[NonEmptyString] = None
     aad_object_id: Optional[NonEmptyString] = None


### PR DESCRIPTION
This pull request makes a minor update to the `ConversationAccount` model by changing the type of the `conversation_type` field to be optional. This improves the model's flexibility and ensures that the field can be omitted when necessary.