### PR TITLE
Fix for proactive experimental sample in WC (#217)

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/conversation_account.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/conversation_account.py
@@ -32,7 +32,7 @@ class ConversationAccount(AgentsModel):
     """
 
     is_group: Optional[bool] = None
-    conversation_type: NonEmptyString = None
+    conversation_type: Optional[NonEmptyString] = None
     id: NonEmptyString
     name: Optional[NonEmptyString] = None
     aad_object_id: Optional[NonEmptyString] = None


### PR DESCRIPTION
This pull request makes a minor update to the `ConversationAccount` model in `microsoft_agents/activity/conversation_account.py` to improve type consistency.

* Changed the type of the `conversation_type` field from `NonEmptyString` to `Optional[NonEmptyString]`, allowing it to be `None` if not provided.