### PR TITLE
Disable Streaming Response when channel = teams and request type is agentic.

### DIFF
--- a/libraries/microsoft-agents-hosting-aiohttp/microsoft_agents/hosting/aiohttp/app/streaming/streaming_response.py
+++ b/libraries/microsoft-agents-hosting-aiohttp/microsoft_agents/hosting/aiohttp/app/streaming/streaming_response.py
@@ -251,8 +251,13 @@ class StreamingResponse:
 
     def _set_defaults(self, context: "TurnContext"):
         if Channels.ms_teams == context.activity.channel_id.channel:
-            self._is_streaming_channel = True
-            self._interval = 1.0
+            if context.activity.is_agentic_request():
+                # Agentic requests do not support streaming responses at this time.
+                # TODO : Enable streaming for agentic requests when supported.
+                self._is_streaming_channel = False
+            else:
+                self._is_streaming_channel = True
+                self._interval = 1.0
         elif Channels.direct_line == context.activity.channel_id.channel:
             self._is_streaming_channel = True
             self._interval = 0.5


### PR DESCRIPTION
This pull request updates the streaming response logic to handle agentic requests differently in the `microsoft_agents/hosting/aiohttp/app/streaming/streaming_response.py` file. The main change ensures that agentic requests are not treated as streaming, with a clear TODO for future support.

Streaming logic update:

* In the `_set_defaults` method, agentic requests detected via `context.activity.is_agentic_request()` are now explicitly set to not use streaming responses (`self._is_streaming_channel = False`), with a TODO comment for future enablement.