### PR TITLE
Removing necessity of service_url when delivery_mode is expect_replies

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/channel_service_adapter.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/channel_service_adapter.py
@@ -351,8 +351,7 @@ class ChannelServiceAdapter(ChannelAdapter, ABC):
             DeliveryModes.expect_replies,
             DeliveryModes.stream,
         ]:
-            if not activity.service_url:  # this is breaking...
-                return False
+            return False
         return True
 
     async def process_activity(


### PR DESCRIPTION
This pull request improves how connector clients are managed in the channel service adapter, ensuring that resources are only created and cleaned up when necessary. The main changes introduce a check to determine if a connector client is needed based on the activity's delivery mode and service URL, which helps prevent unnecessary resource allocation and potential errors.

Resource management improvements:

* Added the `_resolve_if_connector_client_is_needed` method to decide if a connector client should be created, based on the activity's delivery mode and presence of a service URL.
* Updated the `process_activity` method to only create and close a `ConnectorClient` if it is actually needed, improving efficiency and preventing errors when the service URL is missing. [[1]](diffhunk://#diff-935f31e7436a6b94b74346a295724e8c816f07b2eecbd3c6b115a59c2e747391L406-R422) [[2]](diffhunk://#diff-935f31e7436a6b94b74346a295724e8c816f07b2eecbd3c6b115a59c2e747391R436)

Other minor improvements:

* In the `create_reply` method, wrapped `service_url` with `SkipNone` to handle cases where the value may be `None`.