### PR TITLE
Adding configurability for CopilotClient ClientSession creation

### DIFF
--- a/dev/integration/tests/test_copilot_client.py
+++ b/dev/integration/tests/test_copilot_client.py
@@ -1,0 +1,61 @@
+import pytest
+
+from aiohttp.web import Request, Response, Application
+
+from microsoft_agents.activity import Activity
+
+from microsoft_agents.copilotstudio.client import (
+    CopilotClient,
+    ConnectionSettings,
+    PowerPlatformEnvironment
+)
+
+from microsoft_agents.testing.integration.core import (
+    AiohttpRunner
+)
+
+def mock_mcs_handler(activity: Activity) -> Awaitable[[Request], Response]:
+    """Creates a mock handler for MCS endpoint returning the given activity."""
+    async def handler(request: Request) -> Response:
+        activity_data = activity.model_dump_json(exclude_unset=True)
+        return Response(
+            body=activity_data
+        )
+    return handler
+
+def mock_mcs_endpoint(
+        mocker,
+        activity: Activity,
+        path: str,
+        port: int
+    ) -> AiohttpRunner:
+    """Mock MCS responses for testing."""
+
+    PowerPlatformEnvironment.get_copilot_studio_connection_url = mocker.MagicMock(
+        return_value=f"http://localhost:{port}{path}"
+    )
+
+    app = Application()
+    app.router.add_post(path, mock_mcs_handler(activity))
+
+    return AiohttpRunner(app, port=port)
+
+
+@pytest.mark.asyncio
+async def test_start_conversation_and_ask_question(mocker):
+
+    activity = Activity(
+        type="message"
+    )
+
+    runner = mock_mcs_endpoint(mocker, activity, "/mcs-endpoint", port=8081)
+
+    await with runner:
+        settings = ConnectionSettings("environment-id", "agent-id")
+        client = CopilotClient(settings=settings, token="test-token")
+
+        async for conv_activity in client.start_conversation():
+            assert conv_activity.type == "message"
+
+        async for question_activity in client.ask_question("Hello!"):
+            assert question_activity.type == "message"

--- a/libraries/microsoft-agents-copilotstudio-client/microsoft_agents/copilotstudio/client/connection_settings.py
+++ b/libraries/microsoft-agents-copilotstudio-client/microsoft_agents/copilotstudio/client/connection_settings.py
@@ -18,6 +18,7 @@ class ConnectionSettings(DirectToEngineConnectionSettingsProtocol):
         cloud: Optional[PowerPlatformCloud],
         copilot_agent_type: Optional[AgentType],
         custom_power_platform_cloud: Optional[str],
+        client_session_defaults: Optional[dict] = None,
     ) -> None:
         self.environment_id = environment_id
         self.agent_identifier = agent_identifier
@@ -30,3 +31,4 @@ class ConnectionSettings(DirectToEngineConnectionSettingsProtocol):
         self.cloud = cloud or PowerPlatformCloud.PROD
         self.copilot_agent_type = copilot_agent_type or AgentType.PUBLISHED
         self.custom_power_platform_cloud = custom_power_platform_cloud
+        self.client_session_defaults = client_session_defaults or {}

--- a/libraries/microsoft-agents-copilotstudio-client/microsoft_agents/copilotstudio/client/copilot_client.py
+++ b/libraries/microsoft-agents-copilotstudio-client/microsoft_agents/copilotstudio/client/copilot_client.py
@@ -28,7 +28,9 @@ class CopilotClient:
     async def post_request(
         self, url: str, data: dict, headers: dict
     ) -> AsyncIterable[Activity]:
-        async with aiohttp.ClientSession(**self.settings.client_session_defaults) as session:
+        async with aiohttp.ClientSession(
+            **self.settings.client_session_defaults
+        ) as session:
             async with session.post(url, json=data, headers=headers) as response:
                 if response.status != 200:
                     # self.logger(f"Error sending request: {response.status}")

--- a/libraries/microsoft-agents-copilotstudio-client/microsoft_agents/copilotstudio/client/copilot_client.py
+++ b/libraries/microsoft-agents-copilotstudio-client/microsoft_agents/copilotstudio/client/copilot_client.py
@@ -28,7 +28,7 @@ class CopilotClient:
     async def post_request(
         self, url: str, data: dict, headers: dict
     ) -> AsyncIterable[Activity]:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(**self.settings.client_session_defaults) as session:
             async with session.post(url, json=data, headers=headers) as response:
                 if response.status != 200:
                     # self.logger(f"Error sending request: {response.status}")


### PR DESCRIPTION
This pull request updates the way HTTP client sessions are configured in the Copilot Studio client, allowing for more flexible session customization. The main change is the introduction of a `client_session_defaults` option in the connection settings, which is then used to configure the underlying `aiohttp.ClientSession` in API requests.

**Session customization improvements:**

* Added a new `client_session_defaults` parameter to the `ConnectionSettings` class initializer, allowing users to specify custom options for `aiohttp.ClientSession`.
* Set `self.client_session_defaults` in the `ConnectionSettings` class, defaulting to an empty dictionary if none is provided.

**API request handling:**

* Updated the `CopilotClient.post_request` method to use the `client_session_defaults` from the connection settings when creating the `aiohttp.ClientSession`, enabling custom session configuration for outgoing requests.