### PR TITLE
Python nightlies

### DIFF
--- a/.github/actions/get-ado-token/action.yml
+++ b/.github/actions/get-ado-token/action.yml
@@ -1,0 +1,35 @@
+name: Get Azure DevOps Access Token
+description: Get an access token to authenticate with Azure DevOps
+
+inputs:
+  client-id:
+    description: "The client ID of the application calling Azure DevOps"
+    required: true
+  tenant-id:
+    description: "The tenant ID of the application calling Azure DevOps"
+    required: true
+  organization:
+    description: "The Azure DevOps organization to authenticate with"
+    required: true
+
+outputs:
+  token:
+    description: "The access token to authenticate with Azure DevOps"
+    value: ${{ steps.ADOAuth.outputs.token }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: OIDC Login with AzPowershell
+      uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        allow-no-subscriptions: true
+
+    - name: Get Azure DevOps Access Token
+      shell: pwsh
+      id: ADOAuth
+      run: |
+        $accessToken = az account get-access-token --resource="https://${{inputs.organization}}.visualstudio.com" --query accessToken
+        "token=$accessToken" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,86 @@
+name: Nightly Build when something has changed in the last 24 hrs.
+
+on:
+  schedule:
+    - cron: "0 10 * * *" # runs at 2am PST (10am UTC) every day
+  workflow_dispatch:
+
+env:
+  AzDevOpsPipelineId: TBD # TODO: Update with actual Azure DevOps Pipeline ID
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check_date:
+    runs-on: ubuntu-latest
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: print latest_commit
+        run: echo ${{ github.sha }}
+      - id: should_run
+        continue-on-error: true
+        name: check latest commit is less than a day
+        if: ${{ github.event_name == 'schedule' }}
+        run: test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "should_run=false" >> $GITHUB_OUTPUT
+
+  trigger-nightly:
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    name: Nightly Build when something has changed in the last 24 hrs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get Azure DevOps Access Token
+        id: getToken
+        uses: "./.github/actions/get-ado-token"
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          organization: ${{ vars.AZDEVOPS_ORGANIZATION }}
+      - name: Trigger Azure DevOps Pipeline
+        id: trigger
+        run: |
+          response=$(curl -v -X POST \
+            -H "Authorization: Bearer ${{ steps.getToken.outputs.token }}" \
+            -H "Content-Type: application/json" \
+            -d '{"resources": {"repositories": {"self": {"refName": "refs/heads/main"}}},"variables": {"ProjectBranch": {"value": "${{ github.head_ref || github.ref_name }}"}}}' \
+            ${{ vars.AZDEVOPS_URL }}/_apis/pipelines/${{ env.AzDevOpsPipelineId }}/runs?api-version=7.1)
+          echo $BRANCH_NAME
+          echo $response
+          echo "::set-output name=run_id::$(echo $response | jq -r .id)"
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      #          -d '{"resources": {"repositories": {"self": {"refName": "refs/heads/main"}}}}' \
+      #          refs/heads/users/mbarbour/pipelineUpdate      
+      - name: Monitor Pipeline Run
+        run: |
+          run_id=${{ steps.trigger.outputs.run_id }}
+          status="inProgress"
+          while [ "$status" == "inProgress" ] || [ "$status" == "notStarted" ] || [ "$status" == "canceling" ]  ; do
+            response=$(curl -X GET \
+              -H "Authorization: Bearer ${{ steps.getToken.outputs.token }}" \
+              ${{ vars.AZDEVOPS_URL }}/_apis/pipelines/${{ env.AzDevOpsPipelineId }}/runs/$run_id?api-version=7.1)
+            status=$(echo $response | jq -r .state)
+            r1=$(echo $response | jq -r .result)
+            weblink=$(echo $response | jq -r ._links.web.href)
+            echo "Pipeline status: $status"
+            echo "Result response: $r1"
+            echo "WebLink: $weblink"
+            if [ "$status" == "completed" ]; then
+              result=$(echo $response | jq -r .result)
+              if [ "$result" == "succeeded" ]; then
+                echo "Pipeline succeeded"
+                exit 0
+              else
+                echo "::error file={name},line={line},endLine={endLine},title={title}::Pipeline failed with result: $result"
+                echo "Pipeline failed with result: $result"
+                exit 1
+              fi
+            fi
+            sleep 10
+          done


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate nightly builds that trigger an Azure DevOps pipeline only if there have been code changes in the last 24 hours. It also adds a custom composite action to securely obtain an Azure DevOps access token using OIDC authentication. These changes help streamline CI/CD processes and improve security by using short-lived tokens.

**New GitHub Actions Workflow for Nightly Builds:**

- Added `.github/workflows/nightly.yml` to run a nightly build that checks for code changes in the last 24 hours and, if changes are detected, triggers an Azure DevOps pipeline and monitors its status.
  - Includes logic to skip the pipeline trigger if there are no recent changes.
  - Uses secure token-based authentication to interact with Azure DevOps.
  - Monitors the pipeline run and reports success or failure.

**Reusable Azure DevOps Token Action:**

- Introduced `.github/actions/get-ado-token/action.yml`, a composite GitHub Action that authenticates with Azure DevOps using OIDC and retrieves an access token for use in workflows.
  - Accepts `client-id`, `tenant-id`, and `organization` as inputs.
  - Outputs a short-lived access token for secure API calls.

These changes improve automation efficiency, reduce unnecessary pipeline runs, and enhance security for CI/CD integrations.