### PR TITLE
Fixing opentelemetry testing utility

### DIFF
--- a/tests/_common/_tests/test_delta_metric_reader.py
+++ b/tests/_common/_tests/test_delta_metric_reader.py
@@ -198,12 +198,9 @@ def test_output_structure_compatible_with_helpers():
 
     data = delta.get_metrics_data()
 
-    assert hasattr(data, "resource_metrics")
-    rm = data.resource_metrics[0]
-    assert hasattr(rm, "scope_metrics")
-    sm = rm.scope_metrics[0]
-    assert hasattr(sm, "metrics")
-    m = sm.metrics[0]
+    # Test that the structure is compatible with find_metric helper
+    m = find_metric(data, "compat")
+    assert m is not None
     assert m.name == "compat"
     assert hasattr(m.data, "data_points")
     dp = m.data.data_points[0]


### PR DESCRIPTION
With an updated version of OTEL, aunit test for the internal DeltaMetricReader fails. This fixes that by reusing one of the utility functions during that test.