### PR TITLE
fix(teams): pass channel_info/team_info to lifecycle handler dispatches

### DIFF
--- a/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/teams_activity_handler.py
+++ b/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/teams_activity_handler.py
@@ -526,25 +526,45 @@ class TeamsActivityHandler(ActivityHandler):
             event_type = channel_data.event_type
 
             if event_type == "channelCreated":
-                return await self.on_teams_channel_created(turn_context)
+                return await self.on_teams_channel_created(
+                    channel_data.channel, channel_data.team, turn_context
+                )
             elif event_type == "channelDeleted":
-                return await self.on_teams_channel_deleted(turn_context)
+                return await self.on_teams_channel_deleted(
+                    channel_data.channel, channel_data.team, turn_context
+                )
             elif event_type == "channelRenamed":
-                return await self.on_teams_channel_renamed(turn_context)
+                return await self.on_teams_channel_renamed(
+                    channel_data.channel, channel_data.team, turn_context
+                )
             elif event_type == "teamArchived":
-                return await self.on_teams_team_archived(turn_context)
+                return await self.on_teams_team_archived(
+                    channel_data.team, turn_context
+                )
             elif event_type == "teamDeleted":
-                return await self.on_teams_team_deleted(turn_context)
+                return await self.on_teams_team_deleted(
+                    channel_data.team, turn_context
+                )
             elif event_type == "teamHardDeleted":
-                return await self.on_teams_team_hard_deleted(turn_context)
+                return await self.on_teams_team_hard_deleted(
+                    channel_data.team, turn_context
+                )
             elif event_type == "channelRestored":
-                return await self.on_teams_channel_restored(turn_context)
+                return await self.on_teams_channel_restored(
+                    channel_data.channel, channel_data.team, turn_context
+                )
             elif event_type == "teamRenamed":
-                return await self.on_teams_team_renamed(turn_context)
+                return await self.on_teams_team_renamed(
+                    channel_data.team, turn_context
+                )
             elif event_type == "teamRestored":
-                return await self.on_teams_team_restored(turn_context)
+                return await self.on_teams_team_restored(
+                    channel_data.team, turn_context
+                )
             elif event_type == "teamUnarchived":
-                return await self.on_teams_team_unarchived(turn_context)
+                return await self.on_teams_team_unarchived(
+                    channel_data.team, turn_context
+                )
 
         return await super().on_conversation_update_activity(turn_context)
 


### PR DESCRIPTION
The Teams handler's [lifecycle dispatcher](https://github.com/microsoft/Agents-for-python/blob/2908ee33b3b1e0042850a551442af1d64094877c/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/teams_activity_handler.py#L528-L547) calls 10 channel/team event handlers with 1 arg, but [every one of those methods needs 3](https://github.com/microsoft/Agents-for-python/blob/2908ee33b3b1e0042850a551442af1d64094877c/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/teams_activity_handler.py#L721-L829). [Sixteen lines above](https://github.com/microsoft/Agents-for-python/blob/2908ee33b3b1e0042850a551442af1d64094877c/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/teams_activity_handler.py#L511-L515) the same file dispatches `members_added` correctly, the file [imports `ChannelInfo`](https://github.com/microsoft/Agents-for-python/blob/2908ee33b3b1e0042850a551442af1d64094877c/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/teams_activity_handler.py#L19) only to type those signatures, and the [.NET sibling does it the right way](https://github.com/microsoft/Agents-for-net/blob/e047a5e68b1647e4a2d667339b65e864bdd6986e/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Compat/TeamsActivityHandler.cs#L503-L504).

Anyone who installs an agents-for-python bot in a Teams team and then creates, renames, or deletes a channel gets a `TypeError` echoed into the channel by the default error handler. Shipped Aug 2025, untouched since.

Fix passes `channel_data.channel` and `channel_data.team` (already in scope) to all 10 dispatches.