### PR TITLE
Removing confusing field from CosmosDBStorageConfig

### DIFF
--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
@@ -52,33 +52,41 @@ class CosmosDBStorage(AsyncStorageBase):
         self._lock: asyncio.Lock = asyncio.Lock()
 
     def _create_client(self) -> CosmosClient:
-        if self._config.url:
-            if not self._config.credential:
-                raise ValueError(
-                    storage_errors.InvalidConfiguration.format(
-                        "Credential is required when using a custom service URL"
-                    )
+
+        if not self._config.cosmos_db_endpoint:
+            raise ValueError(
+                storage_errors.InvalidConfiguration.format(
+                    "Cosmos DB Endpoint is required."
                 )
-            return CosmosClient(
-                url=self._config.url, credential=self._config.credential
             )
 
-        connection_policy = self._config.cosmos_client_options.get(
-            "connection_policy", documents.ConnectionPolicy()
-        )
+        if self._config.credential or self._config.auth_key:
+            cred = (
+                self._config.credential
+                if self._config.credential
+                else self._config.auth_key
+            )
 
-        # kwargs 'connection_verify' is to handle CosmosClient overwriting the
-        # ConnectionPolicy.DisableSSLVerification value.
-        return CosmosClient(
-            self._config.cosmos_db_endpoint,
-            self._config.auth_key,
-            consistency_level=self._config.cosmos_client_options.get(
-                "consistency_level", None
-            ),
-            **{
-                "connection_policy": connection_policy,
-                "connection_verify": not connection_policy.DisableSSLVerification,
-            },
+            connection_policy = self._config.cosmos_client_options.get(
+                "connection_policy", documents.ConnectionPolicy()
+            )
+
+            return CosmosClient(
+                url=self._config.cosmos_db_endpoint,
+                credential=cred,
+                consistency_level=self._config.cosmos_client_options.get(
+                    "consistency_level", None
+                ),
+                **{
+                    "connection_policy": connection_policy,
+                    "connection_verify": not connection_policy.DisableSSLVerification,
+                },
+            )
+
+        raise ValueError(
+            storage_errors.InvalidConfiguration.format(
+                "Either Cosmos DB Credential or Auth Key is required."
+            )
         )
 
     def _sanitize(self, key: str) -> str:

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
@@ -54,11 +54,7 @@ class CosmosDBStorage(AsyncStorageBase):
     def _create_client(self) -> CosmosClient:
 
         if not self._config.cosmos_db_endpoint:
-            raise ValueError(
-                storage_errors.CosmosDbEndpointRequired.format(
-                    "Cosmos DB Endpoint is required."
-                )
-            )
+            raise ValueError(str(storage_errors.CosmosDbEndpointRequired))
 
         if self._config.credential or self._config.auth_key:
             cred = (
@@ -83,11 +79,7 @@ class CosmosDBStorage(AsyncStorageBase):
                 },
             )
 
-        raise ValueError(
-            storage_errors.CosmosDbAuthKeyRequired.format(
-                "Either Cosmos DB Credential or Auth Key is required."
-            )
-        )
+        raise ValueError(str(storage_errors.CosmosDbAuthKeyRequired))
 
     def _sanitize(self, key: str) -> str:
         return sanitize_key(

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
@@ -55,7 +55,7 @@ class CosmosDBStorage(AsyncStorageBase):
 
         if not self._config.cosmos_db_endpoint:
             raise ValueError(
-                storage_errors.InvalidConfiguration.format(
+                storage_errors.CosmosDbEndpointRequired.format(
                     "Cosmos DB Endpoint is required."
                 )
             )
@@ -84,7 +84,7 @@ class CosmosDBStorage(AsyncStorageBase):
             )
 
         raise ValueError(
-            storage_errors.InvalidConfiguration.format(
+            storage_errors.CosmosDbAuthKeyRequired.format(
                 "Either Cosmos DB Credential or Auth Key is required."
             )
         )

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -1,10 +1,12 @@
 import json
-import warnings
+import logging
 
 from azure.core.credentials_async import AsyncTokenCredential
 from microsoft_agents.storage.cosmos.errors import storage_errors
 
 from .key_ops import sanitize_key
+
+logger = logging.getLogger(__name__)
 
 
 class CosmosDBStorageConfig:
@@ -32,7 +34,7 @@ class CosmosDBStorageConfig:
         :param cosmos_client_options: The options for the CosmosClient. Currently only supports connection_policy and
             consistency_level
         :param container_throughput: The throughput set when creating the Container. Defaults to 400.
-        :param key_suffix: The suffix to be added to every key. The keySuffix must contain only valid ComosDb
+        :param key_suffix: The suffix to be added to every key. The keySuffix must contain only valid CosmosDb
             key characters. (e.g. not: '\\', '?', '/', '#', '*')
         :param compatibility_mode: True if keys should be truncated in order to support previous CosmosDb
             max key length of 255.
@@ -48,10 +50,8 @@ class CosmosDBStorageConfig:
         )
 
         if "url" in kwargs:
-            warnings.warn(
-                "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead.",
-                DeprecationWarning,
-                stacklevel=2,
+            logger.warning(
+                "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead."
             )
             if not self.cosmos_db_endpoint:
                 self.cosmos_db_endpoint = kwargs.get("url", "")

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -49,7 +49,7 @@ class CosmosDBStorageConfig:
         if "url" in kwargs:
             raise ValueError(
                 storage_errors.InvalidConfiguration.format(
-                    "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead."
+                    "The 'url' parameter is no longer supported. Please use 'cosmos_db_endpoint' instead."
                 )
             )
 

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -51,8 +51,10 @@ class CosmosDBStorageConfig:
             warnings.warn(
                 "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
-            self.cosmos_db_endpoint = kwargs.get("url", self.cosmos_db_endpoint)
+            if not self.cosmos_db_endpoint:
+                self.cosmos_db_endpoint = kwargs.get("url", "")
 
         self.auth_key: str = auth_key or kwargs.get("auth_key", "")
         self.database_id: str = database_id or kwargs.get("database_id", "")

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -19,8 +19,7 @@ class CosmosDBStorageConfig:
         container_throughput: int | None = None,
         key_suffix: str = "",
         compatibility_mode: bool = False,
-        url: str = "",
-        credential: AsyncTokenCredential | None = None,
+        credential: Union[AsyncTokenCredential, None] = None,
         **kwargs,
     ):
         """Create the Config object.
@@ -36,7 +35,6 @@ class CosmosDBStorageConfig:
             key characters. (e.g. not: '\\', '?', '/', '#', '*')
         :param compatibility_mode: True if keys should be truncated in order to support previous CosmosDb
             max key length of 255.
-        :param url: The URL to the CosmosDB resource.
         :param credential: The TokenCredential to use for authentication.
         :return CosmosDBConfig:
         """
@@ -60,8 +58,7 @@ class CosmosDBStorageConfig:
         self.compatibility_mode: bool = compatibility_mode or kwargs.get(
             "compatibility_mode", False
         )
-        self.url = url or kwargs.get("url", "")
-        self.credential: AsyncTokenCredential | None = credential
+        self.credential: Union[AsyncTokenCredential, None] = credential
 
     @staticmethod
     def validate_cosmos_db_config(config: "CosmosDBStorageConfig") -> None:

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from azure.core.credentials_async import AsyncTokenCredential
 from microsoft_agents.storage.cosmos.errors import storage_errors
@@ -47,11 +48,11 @@ class CosmosDBStorageConfig:
         )
 
         if "url" in kwargs:
-            raise ValueError(
-                storage_errors.InvalidConfiguration.format(
-                    "The 'url' parameter is no longer supported. Please use 'cosmos_db_endpoint' instead."
-                )
+            warnings.warn(
+                "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead.",
+                DeprecationWarning,
             )
+            self.cosmos_db_endpoint = kwargs.get("url", self.cosmos_db_endpoint)
 
         self.auth_key: str = auth_key or kwargs.get("auth_key", "")
         self.database_id: str = database_id or kwargs.get("database_id", "")

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -19,7 +19,7 @@ class CosmosDBStorageConfig:
         container_throughput: int | None = None,
         key_suffix: str = "",
         compatibility_mode: bool = False,
-        credential: Union[AsyncTokenCredential, None] = None,
+        credential: AsyncTokenCredential | None = None,
         **kwargs,
     ):
         """Create the Config object.
@@ -36,7 +36,7 @@ class CosmosDBStorageConfig:
         :param compatibility_mode: True if keys should be truncated in order to support previous CosmosDb
             max key length of 255.
         :param credential: The TokenCredential to use for authentication.
-        :return CosmosDBConfig:
+        :return CosmosDBStorageConfig:
         """
         config_file: str = kwargs.get("filename", "")
         if config_file:
@@ -50,7 +50,7 @@ class CosmosDBStorageConfig:
             raise ValueError(
                 "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead."
             )
-    
+
         self.auth_key: str = auth_key or kwargs.get("auth_key", "")
         self.database_id: str = database_id or kwargs.get("database_id", "")
         self.container_id: str = container_id or kwargs.get("container_id", "")
@@ -64,7 +64,7 @@ class CosmosDBStorageConfig:
         self.compatibility_mode: bool = compatibility_mode or kwargs.get(
             "compatibility_mode", False
         )
-        self.credential: Union[AsyncTokenCredential, None] = credential
+        self.credential: AsyncTokenCredential | None = credential
 
     @staticmethod
     def validate_cosmos_db_config(config: "CosmosDBStorageConfig") -> None:

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -45,6 +45,12 @@ class CosmosDBStorageConfig:
         self.cosmos_db_endpoint: str = cosmos_db_endpoint or kwargs.get(
             "cosmos_db_endpoint", ""
         )
+
+        if "url" in kwargs:
+            raise ValueError(
+                "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead."
+            )
+    
         self.auth_key: str = auth_key or kwargs.get("auth_key", "")
         self.database_id: str = database_id or kwargs.get("database_id", "")
         self.container_id: str = container_id or kwargs.get("container_id", "")

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -48,7 +48,9 @@ class CosmosDBStorageConfig:
 
         if "url" in kwargs:
             raise ValueError(
-                "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead."
+                storage_errors.InvalidConfiguration.format(
+                    "The 'url' parameter is deprecated. Please use 'cosmos_db_endpoint' instead."
+                )
             )
 
         self.auth_key: str = auth_key or kwargs.get("auth_key", "")

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/errors/error_resources.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/errors/error_resources.py
@@ -28,7 +28,7 @@ class StorageErrorResources:
     )
 
     CosmosDbAuthKeyRequired = ErrorMessage(
-        "CosmosDBStorage: auth_key is required.",
+        "CosmosDBStorage: auth_key or credential is required.",
         -61002,
     )
 

--- a/tests/storage_cosmos/test_cosmos_db_storage.py
+++ b/tests/storage_cosmos/test_cosmos_db_storage.py
@@ -253,9 +253,9 @@ class TestCosmosDBStorage(QuickCRUDStorageTests):
         load_dotenv()
 
         cred = DefaultAzureCredential()
-        url = os.environ.get("TEST_COSMOS_DB_ENDPOINT")
+        url = os.environ.get("TEST_COSMOS_DB_ENDPOINT", "")
         config = CosmosDBStorageConfig(
-            url=url,
+            cosmos_db_endpoint=url,
             credential=cred,
             database_id="test-db",
             container_id="bot-storage",

--- a/tests/storage_cosmos/test_cosmos_db_storage.py
+++ b/tests/storage_cosmos/test_cosmos_db_storage.py
@@ -308,7 +308,7 @@ class TestCosmosDBStorageInit:
     def test_raises_error_when_no_auth_key_or_cred_provided(self, config):
         config.auth_key = None
         config.credential = None
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="auth_key or credential is required"):
             CosmosDBStorage(config)
 
     @pytest.mark.asyncio

--- a/tests/storage_cosmos/test_cosmos_db_storage.py
+++ b/tests/storage_cosmos/test_cosmos_db_storage.py
@@ -194,7 +194,6 @@ async def test_cosmos_db_storage_flow_existing_container_and_persistence(
 
 @pytest.mark.cosmos
 class TestCosmosDBStorage(QuickCRUDStorageTests):
-
     def get_compat_mode(self):
         return False
 
@@ -253,9 +252,9 @@ class TestCosmosDBStorage(QuickCRUDStorageTests):
         load_dotenv()
 
         cred = DefaultAzureCredential()
-        url = os.environ.get("TEST_COSMOS_DB_ENDPOINT", "")
+        cosmos_db_endpoint = os.environ.get("TEST_COSMOS_DB_ENDPOINT", "")
         config = CosmosDBStorageConfig(
-            cosmos_db_endpoint=url,
+            cosmos_db_endpoint=cosmos_db_endpoint,
             credential=cred,
             database_id="test-db",
             container_id="bot-storage",
@@ -284,7 +283,6 @@ class TestCosmosDBStorageWithCompat(TestCosmosDBStorage):
 # @pytest.mark.skipif(not EMULATOR_RUNNING, reason="Needs the emulator to run.")
 @pytest.mark.cosmos
 class TestCosmosDBStorageInit:
-
     def test_raises_error_when_suffix_provided_but_compat(self, config):
         config.auth_key = None
         config.compatibility_mode = True
@@ -299,6 +297,17 @@ class TestCosmosDBStorageInit:
 
     def test_raises_error_when_no_container_id_provided(self, config):
         config.container_id = None
+        with pytest.raises(ValueError):
+            CosmosDBStorage(config)
+
+    def test_raises_error_when_no_endpoint_provided(self, config):
+        config.cosmos_db_endpoint = None
+        with pytest.raises(ValueError):
+            CosmosDBStorage(config)
+
+    def test_raises_error_when_no_auth_key_or_cred_provided(self, config):
+        config.auth_key = None
+        config.credential = None
         with pytest.raises(ValueError):
             CosmosDBStorage(config)
 

--- a/tests/storage_cosmos/test_cosmos_db_storage.py
+++ b/tests/storage_cosmos/test_cosmos_db_storage.py
@@ -302,7 +302,7 @@ class TestCosmosDBStorageInit:
 
     def test_raises_error_when_no_endpoint_provided(self, config):
         config.cosmos_db_endpoint = None
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="cosmos_db_endpoint is required"):
             CosmosDBStorage(config)
 
     def test_raises_error_when_no_auth_key_or_cred_provided(self, config):


### PR DESCRIPTION
This pull request refactors the Cosmos DB storage configuration and client initialization to improve clarity and error handling. The main changes include removing the ambiguous `url` parameter in favor of a more clearly named `cosmos_db_endpoint`, updating client initialization logic to enforce required parameters, and improving error messages for missing configuration.

**Configuration and parameter changes:**

* Removed the `url` parameter from the `CosmosDBStorageConfig` class and replaced all usages with `cosmos_db_endpoint` for clearer intent. [[1]](diffhunk://#diff-1aced9543489d4a04af1e6cf00dc2f936971018999ec318206377f9d42563bf4L23) [[2]](diffhunk://#diff-1aced9543489d4a04af1e6cf00dc2f936971018999ec318206377f9d42563bf4L40) [[3]](diffhunk://#diff-1aced9543489d4a04af1e6cf00dc2f936971018999ec318206377f9d42563bf4L64) [[4]](diffhunk://#diff-33bf0ebefd7a8a5f1ca9e203e8f2fe595caca8831e918c20fd1ca2b12acc66b9L256-R258)

**Client initialization and validation improvements:**

* Updated the `_create_client` method in `cosmos_db_storage.py` to require `cosmos_db_endpoint` and either `credential` or `auth_key`, raising clear `ValueError`s if these are missing. This ensures that clients are only created with valid configurations and provides more helpful error messages. [[1]](diffhunk://#diff-b3d87fd2e67354c662bcc6fd7ed79f3dbcedb88e8a04bb7fe9d6269d612cf792L56-R77) [[2]](diffhunk://#diff-b3d87fd2e67354c662bcc6fd7ed79f3dbcedb88e8a04bb7fe9d6269d612cf792R87-R92)

**Test updates:**

* Updated tests to use the new `cosmos_db_endpoint` parameter instead of the removed `url` parameter.