### PR TITLE
Short-form to fully qualified object naming

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/activity.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/activity.py
@@ -437,7 +437,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     @staticmethod
     def create_contact_relation_update_activity():
         """
-        Creates an instance of the :class:`Activity` class as a ContactRelationUpdateActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as a ContactRelationUpdateActivity object.
 
         :returns: The new contact relation update activity.
         """
@@ -446,7 +446,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     @staticmethod
     def create_conversation_update_activity():
         """
-        Creates an instance of the :class:`Activity` class as a ConversationUpdateActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as a ConversationUpdateActivity object.
 
         :returns: The new conversation update activity.
         """
@@ -455,7 +455,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     @staticmethod
     def create_end_of_conversation_activity():
         """
-        Creates an instance of the :class:`Activity` class as an EndOfConversationActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as an EndOfConversationActivity object.
 
         :returns: The new end of conversation activity.
         """
@@ -464,7 +464,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     @staticmethod
     def create_event_activity():
         """
-        Creates an instance of the :class:`Activity` class as an EventActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as an EventActivity object.
 
         :returns: The new event activity.
         """
@@ -473,7 +473,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     @staticmethod
     def create_handoff_activity():
         """
-        Creates an instance of the :class:`Activity` class as a HandoffActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as a HandoffActivity object.
 
         :returns: The new handoff activity.
         """
@@ -482,7 +482,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     @staticmethod
     def create_invoke_activity():
         """
-        Creates an instance of the :class:`Activity` class as an InvokeActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as an InvokeActivity object.
 
         :returns: The new invoke activity.
         """
@@ -491,7 +491,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     @staticmethod
     def create_message_activity():
         """
-        Creates an instance of the :class:`Activity` class as a MessageActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as a MessageActivity object.
 
         :returns: The new message activity.
         """
@@ -588,7 +588,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         name: str, value: object = None, value_type: str = None, label: str = None
     ):
         """
-        Creates an instance of the :class:`Activity` class as a TraceActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as a TraceActivity object.
 
         :param name: The name of the trace operation to create.
         :param value: Optional, the content for this trace operation.
@@ -612,7 +612,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     @staticmethod
     def create_typing_activity() -> "Activity":
         """
-        Creates an instance of the :class:`Activity` class as a TypingActivity object.
+        Creates an instance of the :class:`microsoft_agents.activity.Activity` class as a TypingActivity object.
 
         :returns: The new typing activity.
         """
@@ -655,7 +655,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         :returns: The array of mentions; or an empty array, if none are found.
 
         .. remarks::
-            This method is defined on the :class:`Activity` class, but is only intended for use with a message activity,
+            This method is defined on the :class:`microsoft_agents.activity.Activity` class, but is only intended for use with a message activity,
             where the activity Activity.Type is set to ActivityTypes.Message.
         """
         if not self.entities:
@@ -683,7 +683,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         :returns: True, if this activity has any content to send; otherwise, false.
 
         .. remarks::
-            This method is defined on the :class:`Activity` class, but is only intended for use with a message activity,
+            This method is defined on the :class:`microsoft_agents.activity.Activity` class, but is only intended for use with a message activity,
             where the activity Activity.Type is set to ActivityTypes.Message.
         """
         if self.text and self.text.strip():

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/activity_handler.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/activity_handler.py
@@ -49,8 +49,8 @@ class ActivityHandler(Agent):
             process, which allows a derived class to provide type-specific logic in a controlled way.
             In a derived class, override this method to add logic that applies to all activity types.
             Also
-            - Add logic to apply before the type-specific logic and before calling :meth:`on_turn()`.
-            - Add logic to apply after the type-specific logic after calling :meth:`on_turn()`.
+            - Add logic to apply before the type-specific logic and before calling :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn`.
+            - Add logic to apply after the type-specific logic after calling :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn`.
         """
         if turn_context is None:
             raise TypeError("ActivityHandler.on_turn(): turn_context cannot be None.")
@@ -145,7 +145,7 @@ class ActivityHandler(Agent):
     async def on_conversation_update_activity(self, turn_context: TurnContextProtocol):
         """
         Invoked when a conversation update activity is received from the channel when the base behavior of
-        :meth:`on_turn()` is used.
+        :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn` is used.
 
         :param turn_context: The context object for this turn
         :type turn_context: :class:`microsoft_agents.activity.TurnContextProtocol`
@@ -153,13 +153,13 @@ class ActivityHandler(Agent):
         :rtype: Awaitable[None]
 
         .. note::
-            When the :meth:`on_turn()` method receives a conversation update activity, it calls this
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn` method receives a conversation update activity, it calls this
             method.
             Also
             - If the conversation update activity indicates that members other than the agent joined the conversation,
-              it calls the :meth:`on_members_added_activity()` method.
+              it calls the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_members_added_activity` method.
             - If the conversation update activity indicates that members other than the agent left the conversation,
-              it calls the :meth:`on_members_removed_activity()` method.
+              it calls the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_members_removed_activity` method.
             - In a derived class, override this method to add logic that applies to all conversation update activities.
               Add logic to apply before the member added or removed logic before the call to this base class method.
         """
@@ -189,7 +189,7 @@ class ActivityHandler(Agent):
         :rtype: Awaitable[None]
 
         .. note::
-            When the :meth:`on_conversation_update_activity()` method receives a conversation
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_conversation_update_activity` method receives a conversation
             update activity that indicates
             one or more users other than the agent are joining the conversation, it calls this method.
         """
@@ -211,7 +211,7 @@ class ActivityHandler(Agent):
         :rtype: Awaitable[None]
 
         .. note::
-            When the :meth:`on_conversation_update_activity()` method receives a conversation
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_conversation_update_activity` method receives a conversation
             update activity that indicates one or more users other than the agent are leaving the conversation,
             it calls this method.
         """
@@ -221,7 +221,7 @@ class ActivityHandler(Agent):
     async def on_message_reaction_activity(self, turn_context: TurnContextProtocol):
         """
         Invoked when an event activity is received from the connector when the base behavior of
-        :meth:`on_turn()` is used.
+        :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn` is used.
 
         :param turn_context: The context object for this turn
         :type turn_context: :class:`microsoft_agents.activity.TurnContextProtocol`
@@ -236,13 +236,13 @@ class ActivityHandler(Agent):
             Message reactions are only supported by a few channels. The activity that the message reaction corresponds
             to is indicated in the reply to Id property. The value of this property is the activity id of a previously
             sent activity given back to the agent as the response from a send call.
-            When the :meth:`on_turn()` method receives a message reaction activity, it calls this
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn` method receives a message reaction activity, it calls this
             method.
 
             - If the message reaction indicates that reactions were added to a message, it calls
-              :meth:`on_reactions_added()`.
+              :meth:`microsoft_agents.hosting.core.ActivityHandler.on_reactions_added`.
             - If the message reaction indicates that reactions were removed from a message, it calls
-              :meth:`on_reactions_removed()`.
+              :meth:`microsoft_agents.hosting.core.ActivityHandler.on_reactions_removed`.
 
             In a derived class, override this method to add logic that applies to all message reaction activities.
             Add logic to apply before the reactions added or removed logic before the call to the this base class
@@ -314,7 +314,7 @@ class ActivityHandler(Agent):
     async def on_event_activity(self, turn_context: TurnContextProtocol):
         """
         Invoked when an event activity is received from the connector when the base behavior of
-        :meth:`on_turn()` is used.
+        :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn` is used.
 
         :param turn_context: The context object for this turn
         :type turn_context: :class:`microsoft_agents.activity.TurnContextProtocol`
@@ -322,9 +322,9 @@ class ActivityHandler(Agent):
         :rtype: Awaitable[None]
 
         .. note::
-            When the :meth:`on_turn()` method receives an event activity, it calls this method.
-            If the activity name is `tokens/response`, it calls :meth:`on_token_response_event()`;
-            otherwise, it calls :meth:`on_event()`.
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn` method receives an event activity, it calls this method.
+            If the activity name is `tokens/response`, it calls :meth:`microsoft_agents.hosting.core.ActivityHandler.on_token_response_event`;
+            otherwise, it calls :meth:`microsoft_agents.hosting.core.ActivityHandler.on_event`.
 
             In a derived class, override this method to add logic that applies to all event activities.
             Add logic to apply before the specific event-handling logic before the call to this base class method.
@@ -344,7 +344,7 @@ class ActivityHandler(Agent):
     ):
         """
         Invoked when a `tokens/response` event is received when the base behavior of
-        :meth:`on_event_activity()` is used.
+        :meth:`microsoft_agents.hosting.core.ActivityHandler.on_event_activity` is used.
         If using an `oauth_prompt`, override this method to forward this activity to the current dialog.
 
         :param turn_context: The context object for this turn
@@ -353,7 +353,7 @@ class ActivityHandler(Agent):
         :rtype: Awaitable[None]
 
         .. note::
-            When the :meth:`on_event()` method receives an event with an activity name of
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_event` method receives an event with an activity name of
             `tokens/response`, it calls this method. If your agent uses an `oauth_prompt`, forward the incoming
             activity to the current dialog.
         """
@@ -364,7 +364,7 @@ class ActivityHandler(Agent):
     ):
         """
         Invoked when an event other than `tokens/response` is received when the base behavior of
-        :meth:`on_event_activity()` is used.
+        :meth:`microsoft_agents.hosting.core.ActivityHandler.on_event_activity` is used.
 
         :param turn_context: The context object for this turn
         :type turn_context: :class:`microsoft_agents.activity.TurnContextProtocol`
@@ -372,7 +372,7 @@ class ActivityHandler(Agent):
         :rtype: Awaitable[None]
 
         .. note::
-            When the :meth:`on_event_activity()` is used method receives an event with an
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_event_activity` is used method receives an event with an
             activity name other than `tokens/response`, it calls this method.
             This method could optionally be overridden if the agent is meant to handle miscellaneous events.
         """
@@ -456,7 +456,7 @@ class ActivityHandler(Agent):
     ):
         """
         Invoked when an activity other than a message, conversation update, or event is received when the base
-        behavior of :meth:`on_turn()` is used.
+        behavior of :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn` is used.
         If overridden, this method could potentially respond to any of the other activity types.
 
         :param turn_context: The context object for this turn
@@ -465,7 +465,7 @@ class ActivityHandler(Agent):
         :rtype: Awaitable[None]
 
         .. note::
-            When the :meth:`on_turn()` method receives an activity that is not a message,
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_turn` method receives an activity that is not a message,
             conversation update, message reaction, or event activity, it calls this method.
         """
         return

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/activity_handler.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/activity_handler.py
@@ -372,8 +372,8 @@ class ActivityHandler(Agent):
         :rtype: Awaitable[None]
 
         .. note::
-            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_event_activity` is used method receives an event with an
-            activity name other than `tokens/response`, it calls this method.
+            When the :meth:`microsoft_agents.hosting.core.ActivityHandler.on_event_activity` method is used, it receives an event with an
+            activity name other than `tokens/response` and calls this method.
             This method could optionally be overridden if the agent is meant to handle miscellaneous events.
         """
         return

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -308,7 +308,7 @@ class AgentApplication(Agent, Generic[StateT]):
         :type activity_type: Union[str, microsoft_agents.activity.ActivityTypes, list[Union[str, microsoft_agents.activity.ActivityTypes]]]
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
-        :param kwargs: Additional route configuration passed to :meth:`add_route`.
+        :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
         def __selector(context: TurnContext):
@@ -345,7 +345,7 @@ class AgentApplication(Agent, Generic[StateT]):
         :type select: Union[str, Pattern[str], list[Union[str, Pattern[str]]]]
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
-        :param kwargs: Additional route configuration passed to :meth:`add_route`.
+        :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
         def __selector(context: TurnContext):
@@ -390,7 +390,7 @@ class AgentApplication(Agent, Generic[StateT]):
         :type type: microsoft_agents.activity.ConversationUpdateTypes
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
-        :param kwargs: Additional route configuration passed to :meth:`add_route`.
+        :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
         def __selector(context: TurnContext):
@@ -444,7 +444,7 @@ class AgentApplication(Agent, Generic[StateT]):
         :type type: microsoft_agents.activity.MessageReactionTypes
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
-        :param kwargs: Additional route configuration passed to :meth:`add_route`.
+        :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
         def __selector(context: TurnContext):
@@ -494,7 +494,7 @@ class AgentApplication(Agent, Generic[StateT]):
         :type type: microsoft_agents.activity.MessageUpdateTypes
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
-        :param kwargs: Additional route configuration passed to :meth:`add_route`.
+        :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
         def __selector(context: TurnContext):
@@ -553,7 +553,7 @@ class AgentApplication(Agent, Generic[StateT]):
 
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
-        :param kwargs: Additional route configuration passed to :meth:`add_route`.
+        :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
         def __selector(context: TurnContext) -> bool:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/app_options.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/app_options.py
@@ -94,6 +94,6 @@ class ApplicationOptions:
     proactive: Optional[ProactiveOptions] = None
     """
     Optional. Options for the proactive messaging subsystem.
-    When set, :attr:`AgentApplication.proactive` is available for storing
+    When set, :attr:`microsoft_agents.hosting.core.AgentApplication.proactive` is available for storing
     conversations and initiating proactive turns.
     """

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/input_file.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/input_file.py
@@ -34,7 +34,7 @@ class InputFileDownloader(ABC):
     Abstract base class for a plugin responsible for downloading files provided by the user.
 
     Implementations should download any files referenced by the incoming activity and return a
-    list of :class:`InputFile` instances representing the downloaded content.
+    list of :class:`microsoft_agents.hosting.core.InputFile` instances representing the downloaded content.
     """
 
     @abstractmethod
@@ -44,6 +44,6 @@ class InputFileDownloader(ABC):
 
         :param context: The turn context for the current request.
         :type context: :class:`microsoft_agents.hosting.core.turn_context.TurnContext`
-        :return: A list of downloaded :class:`InputFile` objects.
+        :return: A list of downloaded :class:`microsoft_agents.hosting.core.InputFile` objects.
         :rtype: list[:class:`microsoft_agents.hosting.core.app.input_file.InputFile`]
         """

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/input_file.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/input_file.py
@@ -44,6 +44,6 @@ class InputFileDownloader(ABC):
 
         :param context: The turn context for the current request.
         :type context: :class:`microsoft_agents.hosting.core.turn_context.TurnContext`
-        :return: A list of downloaded :class:`microsoft_agents.hosting.core.InputFile` objects.
+        :return: A list of downloaded :class:`microsoft_agents.hosting.core.app.input_file.InputFile` objects.
         :rtype: list[:class:`microsoft_agents.hosting.core.app.input_file.InputFile`]
         """

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/input_file.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/input_file.py
@@ -34,7 +34,7 @@ class InputFileDownloader(ABC):
     Abstract base class for a plugin responsible for downloading files provided by the user.
 
     Implementations should download any files referenced by the incoming activity and return a
-    list of :class:`microsoft_agents.hosting.core.InputFile` instances representing the downloaded content.
+    list of :class:`microsoft_agents.hosting.core.app.input_file.InputFile` instances representing the downloaded content.
     """
 
     @abstractmethod

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/conversation.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/conversation.py
@@ -27,7 +27,7 @@ class Conversation(StoreItem):
 
     Instances are typically created via
     :meth:`~microsoft_agents.hosting.core.app.proactive.conversation_builder.ConversationBuilder`
-    or via :meth:`from_turn_context`.
+    or via :meth:`microsoft_agents.hosting.core.app.proactive.Conversation.from_turn_context`.
 
     :param claims: Filtered JWT claims (``aud``, ``azp``, ``appid``, ``idtyp``,
         ``ver``, ``iss``, ``tid``).  May be a raw ``dict`` or a
@@ -57,13 +57,13 @@ class Conversation(StoreItem):
     @classmethod
     def from_turn_context(cls, context: "TurnContext") -> "Conversation":
         """
-        Create a :class:`Conversation` from the current turn context.
+        Create a :class:`microsoft_agents.hosting.core.app.proactive.Conversation` from the current turn context.
 
         :param context: The active turn context.
         :type context: :class:`~microsoft_agents.hosting.core.turn_context.TurnContext`
-        :return: A new :class:`Conversation` capturing the current turn's identity
+        :return: A new :class:`microsoft_agents.hosting.core.app.proactive.Conversation` capturing the current turn's identity
             and conversation reference.
-        :rtype: :class:`Conversation`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.Conversation`
         """
         from microsoft_agents.hosting.core.channel_adapter import ChannelAdapter
 
@@ -96,7 +96,7 @@ class Conversation(StoreItem):
         Reconstruct a :class:`~microsoft_agents.hosting.core.authorization.ClaimsIdentity`
         from a previously persisted claims dict.
 
-        :param claims: Filtered claims dictionary (as produced by :meth:`claims_from_identity`).
+        :param claims: Filtered claims dictionary (as produced by :meth:`microsoft_agents.hosting.core.app.proactive.Conversation.claims_from_identity`).
         :type claims: dict[str, str]
         :return: Reconstituted claims identity.
         :rtype: :class:`~microsoft_agents.hosting.core.authorization.ClaimsIdentity`

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/conversation_builder.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/conversation_builder.py
@@ -84,7 +84,7 @@ class ConversationBuilder:
             when the requestor differs from the audience).
         :type requestor_id: Optional[str]
         :return: A builder pre-populated with the supplied claims.
-        :rtype: :class:`ConversationBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationBuilder`
         """
         builder = cls()
         builder._channel_id = channel_id
@@ -119,7 +119,7 @@ class ConversationBuilder:
         :param service_url: Override the service URL.
         :type service_url: Optional[str]
         :return: A builder pre-populated with the identity's claims.
-        :rtype: :class:`ConversationBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationBuilder`
         """
         builder = cls()
         builder._channel_id = channel_id
@@ -152,7 +152,7 @@ class ConversationBuilder:
         :param user_name: Optional display name.
         :type user_name: Optional[str]
         :return: ``self`` for chaining.
-        :rtype: :class:`ConversationBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationBuilder`
         """
         self._user_id = user_id
         self._user_name = user_name
@@ -174,7 +174,7 @@ class ConversationBuilder:
         :param tenant_id: Optional tenant ID.
         :type tenant_id: Optional[str]
         :return: ``self`` for chaining.
-        :rtype: :class:`ConversationBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationBuilder`
         """
         self._conversation_id = conversation_id
         self._conversation_name = conversation_name
@@ -188,7 +188,7 @@ class ConversationBuilder:
         :param activity_id: The activity ID.
         :type activity_id: str
         :return: ``self`` for chaining.
-        :rtype: :class:`ConversationBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationBuilder`
         """
         self._activity_id = activity_id
         return self

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/conversation_reference_builder.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/conversation_reference_builder.py
@@ -74,7 +74,7 @@ class ConversationReferenceBuilder:
         :param conversation_id: The existing conversation ID.
         :type conversation_id: str
         :return: A builder pre-populated with the channel and conversation.
-        :rtype: :class:`ConversationReferenceBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationReferenceBuilder`
         """
         builder = cls()
         builder._channel_id = channel_id
@@ -103,7 +103,7 @@ class ConversationReferenceBuilder:
             URL for the channel is used.
         :type service_url: Optional[str]
         :return: A builder pre-populated for the agent.
-        :rtype: :class:`ConversationReferenceBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationReferenceBuilder`
         """
         builder = cls()
         builder._channel_id = channel_id
@@ -134,7 +134,7 @@ class ConversationReferenceBuilder:
         :param agent_name: Optional display name.
         :type agent_name: Optional[str]
         :return: ``self`` for chaining.
-        :rtype: :class:`ConversationReferenceBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationReferenceBuilder`
         """
         self._agent_id = agent_id
         self._agent_name = agent_name
@@ -153,7 +153,7 @@ class ConversationReferenceBuilder:
         :param user_name: Optional display name.
         :type user_name: Optional[str]
         :return: ``self`` for chaining.
-        :rtype: :class:`ConversationReferenceBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationReferenceBuilder`
         """
         self._user_id = user_id
         self._user_name = user_name
@@ -166,7 +166,7 @@ class ConversationReferenceBuilder:
         :param service_url: The service URL to use.
         :type service_url: str
         :return: ``self`` for chaining.
-        :rtype: :class:`ConversationReferenceBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationReferenceBuilder`
         """
         self._service_url = service_url
         return self
@@ -178,7 +178,7 @@ class ConversationReferenceBuilder:
         :param activity_id: The activity ID.
         :type activity_id: str
         :return: ``self`` for chaining.
-        :rtype: :class:`ConversationReferenceBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationReferenceBuilder`
         """
         self._activity_id = activity_id
         return self
@@ -190,7 +190,7 @@ class ConversationReferenceBuilder:
         :param locale: BCP-47 locale string (e.g. ``"en-US"``).
         :type locale: str
         :return: ``self`` for chaining.
-        :rtype: :class:`ConversationReferenceBuilder`
+        :rtype: :class:`microsoft_agents.hosting.core.app.proactive.ConversationReferenceBuilder`
         """
         self._locale = locale
         return self

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive.py
@@ -37,19 +37,19 @@ class Proactive(Generic[StateT]):
     """
     Proactive messaging support for :class:`~microsoft_agents.hosting.core.app.agent_application.AgentApplication`.
 
-    This class is attached to :attr:`AgentApplication.proactive` automatically when
+    This class is attached to :attr:`microsoft_agents.hosting.core.AgentApplication.proactive` automatically when
     :attr:`~microsoft_agents.hosting.core.app.app_options.ApplicationOptions.proactive` options are
     provided.  It provides methods to:
 
     * **Persist** a conversation reference so it can be resumed later
-      (:meth:`store_conversation`, :meth:`get_conversation`,
-      :meth:`delete_conversation`).
+      (:meth:`microsoft_agents.hosting.core.app.proactive.Proactive.store_conversation`, :meth:`microsoft_agents.hosting.core.app.proactive.Proactive.get_conversation`,
+      :meth:`microsoft_agents.hosting.core.app.proactive.Proactive.delete_conversation`).
     * **Continue** an existing conversation proactively
-      (:meth:`continue_conversation`).
+      (:meth:`microsoft_agents.hosting.core.app.proactive.Proactive.continue_conversation`).
     * **Send** a single activity into an existing conversation
-      (:meth:`send_activity`).
+      (:meth:`microsoft_agents.hosting.core.app.proactive.Proactive.send_activity`).
     * **Create** a brand-new conversation with a user
-      (:meth:`create_conversation`).
+      (:meth:`microsoft_agents.hosting.core.app.proactive.Proactive.create_conversation`).
 
     Example — store then resume::
 
@@ -243,13 +243,13 @@ class Proactive(Generic[StateT]):
         :type continuation_activity: Optional[:class:`~microsoft_agents.activity.Activity`]
         :param token_handlers: Optional list of OAuth connection names whose
             tokens must be available before *handler* is invoked.  When
-            :attr:`~ProactiveOptions.fail_on_unsigned_in_connections` is ``True``
+            :attr:`~microsoft_agents.hosting.core.app.proactive.ProactiveOptions.fail_on_unsigned_in_connections` is ``True``
             (the default) and a token is missing a :exc:`RuntimeError` is raised.
         :type token_handlers: Optional[list[str]]
         :raises KeyError: If *conversation_id_or_conversation* is a string and the
             conversation is not found in storage.
         :raises RuntimeError: If a required OAuth token is not available and
-            :attr:`~ProactiveOptions.fail_on_unsigned_in_connections` is ``True``.
+            :attr:`~microsoft_agents.hosting.core.app.proactive.ProactiveOptions.fail_on_unsigned_in_connections` is ``True``.
         """
         conversation = await self._resolve_conversation(conversation_id_or_conversation)
 

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/component_dialog.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/component_dialog.py
@@ -27,7 +27,7 @@ class ComponentDialog(Dialog):
 
     def __init__(self, dialog_id: str):
         """
-        Initializes a new instance of the :class:`ComponentDialog`
+        Initializes a new instance of the :class:`microsoft_agents.hosting.dialogs.ComponentDialog`
 
         :param dialog_id: The ID to assign to the new dialog within the parent dialog set.
         :type dialog_id: str
@@ -124,7 +124,7 @@ class ComponentDialog(Dialog):
         .. remarks::
             Containers are typically leaf nodes on the stack but the dev is free to push other dialogs
             on top of the stack which will result in the container receiving an unexpected call to
-            :meth:`ComponentDialog.resume_dialog()` when the pushed on dialog ends.
+            :meth:`microsoft_agents.hosting.dialogs.ComponentDialog.resume_dialog` when the pushed on dialog ends.
             To avoid the container prematurely ending we need to implement this method and simply
             ask our inner dialog stack to re-prompt.
 
@@ -183,11 +183,11 @@ class ComponentDialog(Dialog):
 
     def add_dialog(self, dialog: Dialog) -> object:
         """
-        Adds a :class:`Dialog` to the component dialog and returns the updated component.
+        Adds a :class:`microsoft_agents.hosting.dialogs.Dialog` to the component dialog and returns the updated component.
 
         :param dialog: The dialog to add.
-        :return: The updated :class:`ComponentDialog`.
-        :rtype: :class:`ComponentDialog`
+        :return: The updated :class:`microsoft_agents.hosting.dialogs.ComponentDialog`.
+        :rtype: :class:`microsoft_agents.hosting.dialogs.ComponentDialog`
         """
         self._dialogs.add(dialog)
         if not self.initial_dialog_id:

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/models/dialog_reason.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/models/dialog_reason.py
@@ -7,17 +7,17 @@ class DialogReason(Enum):
     """
     Indicates in which a dialog-related method is being called.
 
-    :var BeginCalled: A dialog is being started through a call to :meth:`DialogContext.begin()`.
+    :var BeginCalled: A dialog is being started through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.begin`.
     :vartype BeginCalled: int
-    :var ContinueCalled: A dialog is being continued through a call to :meth:`DialogContext.continue_dialog()`.
+    :var ContinueCalled: A dialog is being continued through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.continue_dialog`.
     :vartype ContinueCalled: int
-    :var EndCalled: A dialog ended normally through a call to :meth:`DialogContext.end_dialog()
+    :var EndCalled: A dialog ended normally through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.end_dialog`
     :vartype EndCalled: int
-    :var ReplaceCalled: A dialog is ending and replaced through a call to :meth:``DialogContext.replace_dialog()`.
+    :var ReplaceCalled: A dialog is ending and replaced through a call to :meth:``microsoft_agents.hosting.dialogs.DialogContext.replace_dialog`.
     :vartype ReplacedCalled: int
-    :var CancelCalled: A dialog was cancelled as part of a call to :meth:`DialogContext.cancel_all_dialogs()`.
+    :var CancelCalled: A dialog was cancelled as part of a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.cancel_all_dialogs`.
     :vartype CancelCalled: int
-    :var NextCalled: A preceding step was skipped through a call to :meth:`WaterfallStepContext.next()`.
+    :var NextCalled: A preceding step was skipped through a call to :meth:`microsoft_agents.hosting.dialogs.WaterfallStepContext.next`.
     :vartype NextCalled: int
     """
 

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/models/dialog_reason.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/models/dialog_reason.py
@@ -13,7 +13,7 @@ class DialogReason(Enum):
     :vartype ContinueCalled: int
     :var EndCalled: A dialog ended normally through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.end_dialog`
     :vartype EndCalled: int
-    :var ReplaceCalled: A dialog is ending and replaced through a call to :meth:``microsoft_agents.hosting.dialogs.DialogContext.replace_dialog`.
+    :var ReplaceCalled: A dialog is ending and replaced through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.replace_dialog`.
     :vartype ReplacedCalled: int
     :var CancelCalled: A dialog was cancelled as part of a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.cancel_all_dialogs`.
     :vartype CancelCalled: int

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/models/dialog_reason.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/models/dialog_reason.py
@@ -7,7 +7,7 @@ class DialogReason(Enum):
     """
     Indicates in which a dialog-related method is being called.
 
-    :var BeginCalled: A dialog is being started through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.begin`.
+    :var BeginCalled: A dialog is being started through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.begin_dialog`.
     :vartype BeginCalled: int
     :var ContinueCalled: A dialog is being continued through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.continue_dialog`.
     :vartype ContinueCalled: int

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/models/dialog_reason.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/models/dialog_reason.py
@@ -14,7 +14,7 @@ class DialogReason(Enum):
     :var EndCalled: A dialog ended normally through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.end_dialog`
     :vartype EndCalled: int
     :var ReplaceCalled: A dialog is ending and replaced through a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.replace_dialog`.
-    :vartype ReplacedCalled: int
+    :vartype ReplaceCalled: int
     :var CancelCalled: A dialog was cancelled as part of a call to :meth:`microsoft_agents.hosting.dialogs.DialogContext.cancel_all_dialogs`.
     :vartype CancelCalled: int
     :var NextCalled: A preceding step was skipped through a call to :meth:`microsoft_agents.hosting.dialogs.WaterfallStepContext.next`.

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/activity_prompt.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/activity_prompt.py
@@ -44,12 +44,12 @@ class ActivityPrompt(Dialog):
         """Starts the prompt by sending the initial prompt activity.
 
         Initialises persisted state with an attempt count of 0, then calls
-        :meth:`on_prompt`.
+        :meth:`microsoft_agents.hosting.dialogs.ActivityPrompt.on_prompt`.
 
         :param dialog_context: The dialog context for the current turn.
-        :param options: Must be a :class:`PromptOptions` instance.
-        :raises TypeError: If ``options`` is not a :class:`PromptOptions`.
-        :return: :attr:`Dialog.end_of_turn` to wait for the user's response.
+        :param options: Must be a :class:`microsoft_agents.hosting.dialogs.PromptOptions` instance.
+        :raises TypeError: If ``options`` is not a :class:`microsoft_agents.hosting.dialogs.PromptOptions`.
+        :return: :attr:`microsoft_agents.hosting.dialogs.Dialog.end_of_turn` to wait for the user's response.
         """
         if not dialog_context:
             raise TypeError("ActivityPrompt.begin_dialog(): dc cannot be None.")
@@ -85,18 +85,18 @@ class ActivityPrompt(Dialog):
         """Processes the next incoming activity through the prompt.
 
         Increments the persisted attempt count **before** calling the validator,
-        so :attr:`PromptValidatorContext.attempt_count` is at least 1 on the
+        so :attr:`microsoft_agents.hosting.dialogs.PromptValidatorContext.attempt_count` is at least 1 on the
         first validation call.
 
         .. note::
-            This differs from the base :class:`Prompt` class, where
+            This differs from the base :class:`microsoft_agents.hosting.dialogs.Prompt` class, where
             ``attempt_count`` is never stored in state and is always 0 when the
             validator runs.  Code that validates both ``ActivityPrompt`` and
             ``Prompt`` subclasses should rely on
-            :attr:`PromptOptions.number_of_attempts` for consistent counting.
+            :attr:`microsoft_agents.hosting.dialogs.PromptOptions.number_of_attempts` for consistent counting.
 
         :param dialog_context: The dialog context for the current turn.
-        :return: :attr:`Dialog.end_of_turn` while waiting for valid input, or
+        :return: :attr:`microsoft_agents.hosting.dialogs.Dialog.end_of_turn` while waiting for valid input, or
             a Complete result once the validator accepts the activity.
         """
         if not dialog_context:
@@ -194,7 +194,7 @@ class ActivityPrompt(Dialog):
         :param state: Persisted prompt state.
         :param options: Prompt options.
         :return: A result with ``succeeded=True`` and ``value`` set to the
-            current :class:`Activity`.
+            current :class:`microsoft_agents.activity.Activity`.
         """
         result = PromptRecognizerResult()
         result.succeeded = True

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/attachment_prompt.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/attachment_prompt.py
@@ -71,7 +71,7 @@ class AttachmentPrompt(Prompt):
         :param state: Persisted prompt state (unused by AttachmentPrompt).
         :param options: Prompt options (unused by AttachmentPrompt).
         :return: Recognition result with ``succeeded=True`` and the list of
-            :class:`Attachment` objects, or ``succeeded=False`` if none were found.
+            :class:`microsoft_agents.activity.Attachment` objects, or ``succeeded=False`` if none were found.
         """
         if not turn_context:
             raise TypeError("AttachmentPrompt.on_recognize(): context cannot be None.")

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/choice_prompt.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/choice_prompt.py
@@ -142,7 +142,7 @@ class ChoicePrompt(Prompt):
 
         :param activity: The incoming activity (provides ``locale``).
         :param opt: Optional recogniser options (provides ``locale`` fallback).
-        :return: A locale string present in :attr:`_default_choice_options`.
+        :return: A locale string present in :attr:`microsoft_agents.hosting.dialogs.ChoicePrompt._default_choice_options`.
         """
         culture = (
             PromptCultureModels.map_to_nearest_language(activity.locale)

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/confirm_prompt.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/confirm_prompt.py
@@ -33,7 +33,7 @@ class ConfirmPrompt(Prompt):
 
     Returns ``True`` for confirmation, ``False`` for denial.
 
-    Culture/locale detection uses :class:`PromptCultureModels`.  Override
+    Culture/locale detection uses :class:`microsoft_agents.hosting.dialogs.PromptCultureModels`.  Override
     ``default_locale`` or ``choice_defaults`` at construction time to customise
     the displayed choices and the locale used for recognition.
     """

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/prompt_options.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/prompts/prompt_options.py
@@ -7,7 +7,7 @@ from microsoft_agents.hosting.dialogs.choices import Choice, ListStyle
 
 class PromptOptions:
     """
-    Contains settings to pass to a :class:`Prompt` object when the prompt is started.
+    Contains settings to pass to a :class:`microsoft_agents.hosting.dialogs.Prompt` object when the prompt is started.
     """
 
     def __init__(
@@ -20,13 +20,13 @@ class PromptOptions:
         number_of_attempts: int = 0,
     ):
         """
-        Contains settings to pass to a :class:`Prompt` when the prompt is started.
+        Contains settings to pass to a :class:`microsoft_agents.hosting.dialogs.Prompt` when the prompt is started.
 
         :param prompt: The initial prompt activity to send to the user.
         :type prompt: :class:`microsoft_agents.activity.Activity`
         :param retry_prompt: The activity to send when the user's input fails validation.
         :type retry_prompt: :class:`microsoft_agents.activity.Activity`
-        :param choices: The list of choices presented to the user (used by :class:`ChoicePrompt`).
+        :param choices: The list of choices presented to the user (used by :class:`microsoft_agents.hosting.dialogs.ChoicePrompt`).
         :type choices: list[:class:`microsoft_agents.hosting.dialogs.choices.Choice`]
         :param style: Controls how the choice list is rendered.
         :type style: :class:`microsoft_agents.hosting.dialogs.choices.ListStyle`

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/waterfall_dialog.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/waterfall_dialog.py
@@ -18,9 +18,9 @@ from .waterfall_step_context import WaterfallStepContext
 class WaterfallDialog(Dialog):
     """A dialog composed of a fixed, ordered sequence of steps (a waterfall).
 
-    Each step receives a :class:`WaterfallStepContext` and must either:
+    Each step receives a :class:`microsoft_agents.hosting.dialogs.WaterfallStepContext` and must either:
 
-    * return :attr:`Dialog.end_of_turn` to wait for user input before proceeding
+    * return :attr:`microsoft_agents.hosting.dialogs.Dialog.end_of_turn` to wait for user input before proceeding
       to the next step, or
     * call ``await step.next(result)`` / ``await step.begin_dialog(...)`` /
       ``await step.end_dialog(...)`` to advance the flow explicitly.
@@ -44,9 +44,9 @@ class WaterfallDialog(Dialog):
 
         :param dialog_id: Unique ID for this dialog within its parent DialogSet.
         :param steps: Optional list of async callables (step functions).  Each callable
-            must accept a single :class:`WaterfallStepContext` and return a
-            :class:`DialogTurnResult`.  Pass ``None`` or omit to start with an empty
-            waterfall and add steps later with :meth:`add_step`.
+            must accept a single :class:`microsoft_agents.hosting.dialogs.WaterfallStepContext` and return a
+            :class:`microsoft_agents.hosting.dialogs.DialogTurnResult`.  Pass ``None`` or omit to start with an empty
+            waterfall and add steps later with :meth:`microsoft_agents.hosting.dialogs.WaterfallDialog.add_step`.
         :raises TypeError: If ``steps`` is not a list.
         """
         super(WaterfallDialog, self).__init__(dialog_id)
@@ -80,7 +80,7 @@ class WaterfallDialog(Dialog):
 
         :param dialog_context: The dialog context for the current turn.
         :param options: Optional argument passed through to every step as
-            :attr:`WaterfallStepContext.options`.
+            :attr:`microsoft_agents.hosting.dialogs.WaterfallStepContext.options`.
         :return: The result of the first step, or a Complete result if there are
             no steps.
         """
@@ -112,9 +112,9 @@ class WaterfallDialog(Dialog):
     ) -> DialogTurnResult:
         """Continues the waterfall on the next incoming activity.
 
-        Non-message activities are ignored (returns :attr:`Dialog.end_of_turn`).
+        Non-message activities are ignored (returns :attr:`microsoft_agents.hosting.dialogs.Dialog.end_of_turn`).
         For message activities the user's text is forwarded as the result of the
-        previous step via :meth:`resume_dialog`.
+        previous step via :meth:`microsoft_agents.hosting.dialogs.WaterfallDialog.resume_dialog`.
 
         :param dialog_context: The dialog context for the current turn.
         :return: The result of resuming the current step.
@@ -138,7 +138,7 @@ class WaterfallDialog(Dialog):
         step's output.
 
         Called automatically by the dialog system when a child dialog completes or
-        when :meth:`WaterfallStepContext.next` is called explicitly.
+        when :meth:`microsoft_agents.hosting.dialogs.WaterfallStepContext.next` is called explicitly.
 
         :param dialog_context: The dialog context for the current turn.
         :param reason: Why the dialog is being resumed.
@@ -219,7 +219,7 @@ class WaterfallDialog(Dialog):
         last step.
 
         Saves the step index into persisted state, constructs a
-        :class:`WaterfallStepContext`, and delegates to :meth:`on_step`.
+        :class:`microsoft_agents.hosting.dialogs.WaterfallStepContext`, and delegates to :meth:`microsoft_agents.hosting.dialogs.WaterfallDialog.on_step`.
 
         :param dialog_context: The dialog context for the current turn.
         :param index: Zero-based index of the step to run.

--- a/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/waterfall_step_context.py
+++ b/libraries/microsoft-agents-hosting-dialogs/microsoft_agents/hosting/dialogs/waterfall_step_context.py
@@ -8,20 +8,20 @@ from .dialog_state import DialogState
 
 
 class WaterfallStepContext(DialogContext):
-    """Context passed to each step function in a :class:`WaterfallDialog`.
+    """Context passed to each step function in a :class:`microsoft_agents.hosting.dialogs.WaterfallDialog`.
 
-    Inherits from :class:`DialogContext` so step functions can call
-    :meth:`begin_dialog`, :meth:`prompt`, :meth:`end_dialog`, etc. directly on
+    Inherits from :class:`microsoft_agents.hosting.dialogs.DialogContext` so step functions can call
+    :meth:`microsoft_agents.hosting.dialogs.DialogContext.begin_dialog`, :meth:`microsoft_agents.hosting.dialogs.DialogContext.prompt`, :meth:`microsoft_agents.hosting.dialogs.DialogContext.end_dialog`, etc. directly on
     the step context.
 
-    In addition to the standard :class:`DialogContext` interface, a step context
+    In addition to the standard :class:`microsoft_agents.hosting.dialogs.DialogContext` interface, a step context
     provides read-only properties for the current step index, the options passed
     to the waterfall, the reason this step is executing, the result from the
     previous step (or child dialog), and a shared ``values`` dict that persists
     across all steps of the same waterfall instance.
 
-    Call :meth:`next` to skip ahead to the next step without waiting for user
-    input.  Calling :meth:`next` more than once in the same step raises an
+    Call :meth:`microsoft_agents.hosting.dialogs.WaterfallStepContext.next` to skip ahead to the next step without waiting for user
+    input.  Calling :meth:`microsoft_agents.hosting.dialogs.WaterfallStepContext.next` more than once in the same step raises an
     exception.
     """
 
@@ -54,7 +54,7 @@ class WaterfallStepContext(DialogContext):
 
     @property
     def options(self) -> object:
-        """Options originally passed to :meth:`WaterfallDialog.begin_dialog`.
+        """Options originally passed to :meth:`microsoft_agents.hosting.dialogs.WaterfallDialog.begin_dialog`.
         Shared across all steps of the same waterfall run.
         """
         return self._options
@@ -92,7 +92,7 @@ class WaterfallStepContext(DialogContext):
         advance immediately (e.g. when data was already available).
 
         :param result: Value to pass to the next step as
-            :attr:`WaterfallStepContext.result`.
+            :attr:`microsoft_agents.hosting.dialogs.WaterfallStepContext.result`.
         :raises Exception: If called more than once within the same step.
         :return: The result of running the next step.
         """


### PR DESCRIPTION
Change all docstrings from using object short-form naming to the fully qualified name. This is required for generation of the Learn API reference.