### PR TITLE
Instrument Proactive

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive.py
@@ -121,7 +121,9 @@ class Proactive(Generic[StateT]):
         else:
             conversation = context_or_conversation
 
-        with spans.ProactiveStoreConversation(conversation.conversation_reference.conversation.id):
+        with spans.ProactiveStoreConversation(
+            conversation.conversation_reference.conversation.id
+        ):
             conversation.validate()
             key = self._storage_key(conversation.conversation_reference.conversation.id)
             logger.debug("Storing conversation with key: %s", key)
@@ -138,10 +140,12 @@ class Proactive(Generic[StateT]):
             or ``None`` if not found.
         :rtype: Optional[:class:`~microsoft_agents.hosting.core.app.proactive.conversation.Conversation`]
         """
-        with spans.ProactiveGetConversation(conversation_id):
+        with spans.ProactiveGetConversation(conversation_id) as span:
             key = self._storage_key(conversation_id)
             results = await self._storage.read([key], target_cls=Conversation)
-            return results.get(key)
+            conversation = results.get(key)
+            span.share(found=conversation is not None)
+            return conversation
 
     async def delete_conversation(self, conversation_id: str) -> None:
         """
@@ -273,10 +277,12 @@ class Proactive(Generic[StateT]):
                 await self._on_turn(context, handler, token_handlers)
             except Exception as exc:  # noqa: BLE001
                 captured_exc = exc
-            
+
         with spans.ProactiveContinueConversation(conversation_id, continuation):
 
-            await adapter.continue_conversation_with_claims(claims, continuation, _callback)
+            await adapter.continue_conversation_with_claims(
+                claims, continuation, _callback
+            )
 
             if captured_exc is not None:
                 raise captured_exc

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive.py
@@ -16,6 +16,7 @@ from microsoft_agents.hosting.core.storage import Storage
 from .conversation import Conversation
 from .create_conversation_options import CreateConversationOptions
 from .proactive_options import ProactiveOptions
+from .telemetry import spans
 
 if TYPE_CHECKING:
     from microsoft_agents.hosting.core.turn_context import TurnContext
@@ -95,7 +96,7 @@ class Proactive(Generic[StateT]):
 
     async def store_conversation(
         self,
-        context_or_conversation: "TurnContext | Conversation",
+        context_or_conversation: TurnContext | Conversation,
     ) -> None:
         """
         Persist a :class:`~microsoft_agents.hosting.core.app.proactive.conversation.Conversation`
@@ -120,10 +121,11 @@ class Proactive(Generic[StateT]):
         else:
             conversation = context_or_conversation
 
-        conversation.validate()
-        key = self._storage_key(conversation.conversation_reference.conversation.id)
-        logger.debug("Storing conversation with key: %s", key)
-        await self._storage.write({key: conversation})
+        with spans.ProactiveStoreConversation(conversation.conversation_reference.conversation.id):
+            conversation.validate()
+            key = self._storage_key(conversation.conversation_reference.conversation.id)
+            logger.debug("Storing conversation with key: %s", key)
+            await self._storage.write({key: conversation})
 
     async def get_conversation(self, conversation_id: str) -> Optional[Conversation]:
         """
@@ -136,9 +138,10 @@ class Proactive(Generic[StateT]):
             or ``None`` if not found.
         :rtype: Optional[:class:`~microsoft_agents.hosting.core.app.proactive.conversation.Conversation`]
         """
-        key = self._storage_key(conversation_id)
-        results = await self._storage.read([key], target_cls=Conversation)
-        return results.get(key)
+        with spans.ProactiveGetConversation(conversation_id):
+            key = self._storage_key(conversation_id)
+            results = await self._storage.read([key], target_cls=Conversation)
+            return results.get(key)
 
     async def delete_conversation(self, conversation_id: str) -> None:
         """
@@ -147,9 +150,10 @@ class Proactive(Generic[StateT]):
         :param conversation_id: The conversation ID to delete.
         :type conversation_id: str
         """
-        key = self._storage_key(conversation_id)
-        logger.debug("Deleting conversation with key: %s", key)
-        await self._storage.delete([key])
+        with spans.ProactiveDeleteConversation(conversation_id):
+            key = self._storage_key(conversation_id)
+            logger.debug("Deleting conversation with key: %s", key)
+            await self._storage.delete([key])
 
     # ------------------------------------------------------------------
     # Send a single activity
@@ -181,7 +185,9 @@ class Proactive(Generic[StateT]):
             conversation is not found in storage.
         """
         conversation = await self._resolve_conversation(conversation_id_or_conversation)
-        return await Proactive._send_activity_impl(adapter, conversation, activity)
+        conversation_id = conversation.conversation_reference.conversation.id
+        with spans.ProactiveSendActivity(conversation_id, activity):
+            return await Proactive._send_activity_impl(adapter, conversation, activity)
 
     @staticmethod
     async def _send_activity_impl(
@@ -252,6 +258,7 @@ class Proactive(Generic[StateT]):
             :attr:`~ProactiveOptions.fail_on_unsigned_in_connections` is ``True``.
         """
         conversation = await self._resolve_conversation(conversation_id_or_conversation)
+        conversation_id = conversation.conversation_reference.conversation.id
 
         captured_exc: Optional[BaseException] = None
         claims = Conversation.identity_from_claims(conversation.claims)
@@ -266,11 +273,13 @@ class Proactive(Generic[StateT]):
                 await self._on_turn(context, handler, token_handlers)
             except Exception as exc:  # noqa: BLE001
                 captured_exc = exc
+            
+        with spans.ProactiveContinueConversation(conversation_id, continuation):
 
-        await adapter.continue_conversation_with_claims(claims, continuation, _callback)
+            await adapter.continue_conversation_with_claims(claims, continuation, _callback)
 
-        if captured_exc is not None:
-            raise captured_exc
+            if captured_exc is not None:
+                raise captured_exc
 
     # ------------------------------------------------------------------
     # Create a new conversation
@@ -303,40 +312,42 @@ class Proactive(Generic[StateT]):
         new_conversation: Optional[Conversation] = None
         captured_exc: Optional[BaseException] = None
 
-        audience = options.audience or options.identity.get_token_audience()
+        with spans.ProactiveCreateConversation(options):
 
-        async def _callback(context: "TurnContext") -> None:
-            nonlocal new_conversation, captured_exc
-            try:
-                reference = context.activity.get_conversation_reference()
-                new_conversation = Conversation(
-                    claims=options.identity,
-                    conversation_reference=reference,
-                )
+            audience = options.audience or options.identity.get_token_audience()
 
-                if options.store_conversation:
-                    await self.store_conversation(new_conversation)
+            async def _callback(context: "TurnContext") -> None:
+                nonlocal new_conversation, captured_exc
+                try:
+                    reference = context.activity.get_conversation_reference()
+                    new_conversation = Conversation(
+                        claims=options.identity,
+                        conversation_reference=reference,
+                    )
 
-                if handler is not None:
-                    state = await self._load_state(context)
-                    await handler(context, state)
-                    await state.save(context)
-            except Exception as exc:  # noqa: BLE001
-                captured_exc = exc
+                    if options.store_conversation:
+                        await self.store_conversation(new_conversation)
 
-        await adapter.create_conversation(
-            options.identity.get_app_id() or "",
-            options.channel_id,
-            options.service_url,
-            audience,
-            options.parameters,
-            _callback,
-        )
+                    if handler is not None:
+                        state = await self._load_state(context)
+                        await handler(context, state)
+                        await state.save(context)
+                except Exception as exc:  # noqa: BLE001
+                    captured_exc = exc
 
-        if captured_exc is not None:
-            raise captured_exc
+            await adapter.create_conversation(
+                options.identity.get_app_id() or "",
+                options.channel_id,
+                options.service_url,
+                audience,
+                options.parameters,
+                _callback,
+            )
 
-        return new_conversation
+            if captured_exc is not None:
+                raise captured_exc
+
+            return new_conversation
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/constants.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/constants.py
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+SPAN_STORE_CONVERSATION = "agents.proactive.store_conversation"
+SPAN_GET_CONVERSATION = "agents.proactive.get_conversation"
+SPAN_DELETE_CONVERSATION = "agents.proactive.delete_conversation"
+SPAN_SEND_ACTIVITY = "agents.proactive.send_activity"
+SPAN_CONTINUE_CONVERSATION = "agents.proactive.continue_conversation"
+SPAN_CREATE_CONVERSATION = "agents.proactive.create_conversation"

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/spans.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/spans.py
@@ -1,0 +1,129 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+from opentelemetry.trace import Span
+from microsoft_agents.activity import Activity
+from microsoft_agents.hosting.core.telemetry import (
+    AttributeMap,
+    attributes,
+    SimpleSpanWrapper,
+)
+from . import constants
+from ..create_conversation_options import CreateConversationOptions
+
+class ProactiveStoreConversation(SimpleSpanWrapper):
+    """Span for storing a conversation reference in proactive scenarios, starting from when the store operation is initiated until it is completed. This span can be used to correlate telemetry related to storing conversation references in proactive scenarios."""
+
+    def __init__(self, conversation_id: str):
+        """Initializes the ProactiveStoreConversation SpanWrapper.
+
+        :param conversation_id: The ID of the conversation being stored, used to extract attributes for the span
+        """
+        super().__init__(constants.SPAN_STORE_CONVERSATION)
+        self._conversation_id = conversation_id
+
+    def _get_attributes(self) -> AttributeMap:
+        return {
+            attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
+        }
+    
+class ProactiveGetConversation(SimpleSpanWrapper):
+    """Span for getting a conversation reference in proactive scenarios, starting from when the get operation is initiated until it is completed. This span can be used to correlate telemetry related to getting conversation references in proactive scenarios."""
+
+    def __init__(self, conversation_id: str):
+        """Initializes the ProactiveGetConversation SpanWrapper.
+
+        :param conversation_id: The ID of the conversation being retrieved, used to extract attributes for the span
+        """
+        super().__init__(constants.SPAN_GET_CONVERSATION)
+        self._conversation_id = conversation_id
+        self._found: bool | None = None
+
+    def _get_attributes(self) -> AttributeMap:
+        return {
+            attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
+            attributes.CONVERSATION_FOUND: self._found if self._found is not None else attributes.UNKNOWN,
+        }
+    
+    def share(self, found: bool) -> None:
+        """Records to the span whether the conversation being retrieved was found.
+
+        :param found: Whether the conversation being retrieved was found
+        """
+        self._found = found
+    
+class ProactiveDeleteConversation(SimpleSpanWrapper):
+    """Span for deleting a conversation reference in proactive scenarios, starting from when the delete operation is initiated until it is completed. This span can be used to correlate telemetry related to deleting conversation references in proactive scenarios."""
+
+    def __init__(self, conversation_id: str):
+        """Initializes the ProactiveDeleteConversation SpanWrapper.
+
+        :param conversation_id: The ID of the conversation being deleted, used to extract attributes for the span
+        """
+        super().__init__(constants.SPAN_DELETE_CONVERSATION)
+        self._conversation_id = conversation_id
+
+    def _get_attributes(self) -> AttributeMap:
+        return {
+            attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
+        }
+    
+class ProactiveSendActivity(SimpleSpanWrapper):
+    """Span for sending an activity in proactive scenarios, starting from when the send operation is initiated until it is completed. This span can be used to correlate telemetry related to sending activities in proactive scenarios."""
+
+    def __init__(self, conversation_id: str, activity: Activity):
+        """Initializes the ProactiveSendActivity SpanWrapper.
+
+        :param conversation_id: The ID of the conversation the activity is being sent to, used to extract attributes for the span
+        :param activity: The activity being sent, used to extract attributes for the span
+        """
+        super().__init__(constants.SPAN_SEND_ACTIVITY)
+        self._conversation_id = conversation_id
+        self._activity = activity
+
+    def _get_attributes(self) -> AttributeMap:
+        return {
+            attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
+            attributes.ACTIVITY_TYPE: self._activity.type or attributes.UNKNOWN,
+            attributes.ACTIVITY_CHANNEL_ID: self._activity.channel_id or attributes.UNKNOWN,
+        }
+
+class ProactiveContinueConversation(SimpleSpanWrapper):
+    """Span for continuing a conversation in proactive scenarios, starting from when the continue operation is initiated until it is completed. This span can be used to correlate telemetry related to continuing conversations in proactive scenarios."""
+
+    def __init__(self, conversation_id: str, activity: Activity):
+        """Initializes the ProactiveContinueConversation SpanWrapper.
+
+        :param conversation_id: The ID of the conversation being continued, used to extract attributes for the span
+        :param activity: The activity being sent, used to extract attributes for the span
+        """
+        super().__init__(constants.SPAN_CONTINUE_CONVERSATION)
+        self._conversation_id = conversation_id
+        self._activity = activity
+
+    def _get_attributes(self) -> AttributeMap:
+        return {
+            attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
+            attributes.ACTIVITY_TYPE: self._activity.type or attributes.UNKNOWN,
+            attributes.ACTIVITY_CHANNEL_ID: self._activity.channel_id or attributes.UNKNOWN,
+        }
+    
+class ProactiveCreateConversation(SimpleSpanWrapper):
+    """Span for creating a conversation in proactive scenarios, starting from when the create operation is initiated until it is completed. This span can be used to correlate telemetry related to creating conversations in proactive scenarios."""
+
+    def __init__(self, options: CreateConversationOptions):
+        """Initializes the ProactiveCreateConversation SpanWrapper.
+
+        :param options: The options used to create the conversation, used to extract attributes for the span
+        """
+        super().__init__(constants.SPAN_CREATE_CONVERSATION)
+        self._channel_id = options.channel_id
+        self._members_count: str = str(len(options.parameters.members)) if options.parameters and options.parameters.members else attributes.UNKNOWN
+
+    def _get_attributes(self) -> AttributeMap:
+        return {
+            attributes.ACTIVITY_CHANNEL_ID: self._channel_id,
+            attributes.MEMBERS_COUNT: self._members_count,
+        }

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/spans.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/spans.py
@@ -13,6 +13,7 @@ from microsoft_agents.hosting.core.telemetry import (
 from . import constants
 from ..create_conversation_options import CreateConversationOptions
 
+
 class ProactiveStoreConversation(SimpleSpanWrapper):
     """Span for storing a conversation reference in proactive scenarios, starting from when the store operation is initiated until it is completed. This span can be used to correlate telemetry related to storing conversation references in proactive scenarios."""
 
@@ -28,7 +29,8 @@ class ProactiveStoreConversation(SimpleSpanWrapper):
         return {
             attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
         }
-    
+
+
 class ProactiveGetConversation(SimpleSpanWrapper):
     """Span for getting a conversation reference in proactive scenarios, starting from when the get operation is initiated until it is completed. This span can be used to correlate telemetry related to getting conversation references in proactive scenarios."""
 
@@ -44,16 +46,19 @@ class ProactiveGetConversation(SimpleSpanWrapper):
     def _get_attributes(self) -> AttributeMap:
         return {
             attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
-            attributes.CONVERSATION_FOUND: self._found if self._found is not None else attributes.UNKNOWN,
+            attributes.CONVERSATION_FOUND: (
+                self._found if self._found is not None else attributes.UNKNOWN
+            ),
         }
-    
+
     def share(self, found: bool) -> None:
         """Records to the span whether the conversation being retrieved was found.
 
         :param found: Whether the conversation being retrieved was found
         """
         self._found = found
-    
+
+
 class ProactiveDeleteConversation(SimpleSpanWrapper):
     """Span for deleting a conversation reference in proactive scenarios, starting from when the delete operation is initiated until it is completed. This span can be used to correlate telemetry related to deleting conversation references in proactive scenarios."""
 
@@ -69,7 +74,8 @@ class ProactiveDeleteConversation(SimpleSpanWrapper):
         return {
             attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
         }
-    
+
+
 class ProactiveSendActivity(SimpleSpanWrapper):
     """Span for sending an activity in proactive scenarios, starting from when the send operation is initiated until it is completed. This span can be used to correlate telemetry related to sending activities in proactive scenarios."""
 
@@ -87,8 +93,10 @@ class ProactiveSendActivity(SimpleSpanWrapper):
         return {
             attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
             attributes.ACTIVITY_TYPE: self._activity.type or attributes.UNKNOWN,
-            attributes.ACTIVITY_CHANNEL_ID: self._activity.channel_id or attributes.UNKNOWN,
+            attributes.ACTIVITY_CHANNEL_ID: self._activity.channel_id
+            or attributes.UNKNOWN,
         }
+
 
 class ProactiveContinueConversation(SimpleSpanWrapper):
     """Span for continuing a conversation in proactive scenarios, starting from when the continue operation is initiated until it is completed. This span can be used to correlate telemetry related to continuing conversations in proactive scenarios."""
@@ -107,9 +115,11 @@ class ProactiveContinueConversation(SimpleSpanWrapper):
         return {
             attributes.CONVERSATION_ID: self._conversation_id or attributes.UNKNOWN,
             attributes.ACTIVITY_TYPE: self._activity.type or attributes.UNKNOWN,
-            attributes.ACTIVITY_CHANNEL_ID: self._activity.channel_id or attributes.UNKNOWN,
+            attributes.ACTIVITY_CHANNEL_ID: self._activity.channel_id
+            or attributes.UNKNOWN,
         }
-    
+
+
 class ProactiveCreateConversation(SimpleSpanWrapper):
     """Span for creating a conversation in proactive scenarios, starting from when the create operation is initiated until it is completed. This span can be used to correlate telemetry related to creating conversations in proactive scenarios."""
 
@@ -120,7 +130,11 @@ class ProactiveCreateConversation(SimpleSpanWrapper):
         """
         super().__init__(constants.SPAN_CREATE_CONVERSATION)
         self._channel_id = options.channel_id
-        self._members_count: str = str(len(options.parameters.members)) if options.parameters and options.parameters.members else attributes.UNKNOWN
+        self._members_count: str | int = (
+            len(options.parameters.members)
+            if options.parameters and options.parameters.members
+            else attributes.UNKNOWN
+        )
 
     def _get_attributes(self) -> AttributeMap:
         return {

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/spans.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/spans.py
@@ -31,7 +31,7 @@ class ProactiveStoreConversation(SimpleSpanWrapper):
 
 
 class ProactiveGetConversation(SimpleSpanWrapper):
-    """Span for getting a conversation reference in proactive scenarios, starting from when the get operation is initiated until it is completed. This span can be used to correlate telemetry related to getting conversation references in proactive scenarios."""
+    """Span for getting a conversation reference in proactive scenarios."""
 
     def __init__(self, conversation_id: str):
         """Initializes the ProactiveGetConversation SpanWrapper.

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/spans.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/telemetry/spans.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from opentelemetry.trace import Span
 from microsoft_agents.activity import Activity
 from microsoft_agents.hosting.core.telemetry import (
     AttributeMap,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/telemetry/attributes.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/telemetry/attributes.py
@@ -21,6 +21,7 @@ AUTH_SCOPES = "auth.scopes"
 AUTH_SUCCESS = "auth.success"
 
 CONNECTION_NAME = "auth.connection.name"
+CONVERSATION_FOUND = "proactive.conversation_found"
 CONVERSATION_ID = "activity.conversation.id"
 
 HTTP_METHOD = "http.method"
@@ -29,6 +30,8 @@ HTTP_STATUS_CODE = "http.status_code"
 IS_AGENTIC = "activity.is_agentic_request"
 
 KEY_COUNT = "storage.keys.count"
+
+MEMBERS_COUNT = "proactive.members_count"
 
 OPERATION = "operation"
 

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/telemetry/attributes.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/telemetry/attributes.py
@@ -21,7 +21,7 @@ AUTH_SCOPES = "auth.scopes"
 AUTH_SUCCESS = "auth.success"
 
 CONNECTION_NAME = "auth.connection.name"
-CONVERSATION_FOUND = "proactive.conversation_found"
+CONVERSATION_FOUND = "proactive.conversation.found"
 CONVERSATION_ID = "activity.conversation.id"
 
 HTTP_METHOD = "http.method"
@@ -31,7 +31,7 @@ IS_AGENTIC = "activity.is_agentic_request"
 
 KEY_COUNT = "storage.keys.count"
 
-MEMBERS_COUNT = "proactive.members_count"
+MEMBERS_COUNT = "proactive.members.count"
 
 OPERATION = "operation"
 

--- a/tests/hosting_core/app/proactive/test_conversation.py
+++ b/tests/hosting_core/app/proactive/test_conversation.py
@@ -69,7 +69,9 @@ class TestConversationInit:
 class TestConversationFromTurnContext:
     def test_from_turn_context_extracts_reference_and_identity(self):
         ref = _make_reference("ctx-conv")
-        identity = ClaimsIdentity(claims={"aud": "app-id", "tid": "t"}, is_authenticated=True)
+        identity = ClaimsIdentity(
+            claims={"aud": "app-id", "tid": "t"}, is_authenticated=True
+        )
 
         ctx = MagicMock()
         ctx.activity.get_conversation_reference.return_value = ref
@@ -195,7 +197,9 @@ class TestConversationSerialization:
     def test_round_trip_preserves_service_url(self):
         original = Conversation(
             claims={},
-            conversation_reference=_make_reference(service_url="https://custom.service/"),
+            conversation_reference=_make_reference(
+                service_url="https://custom.service/"
+            ),
         )
         json_data = original.store_item_to_json()
         restored = Conversation.from_json_to_store_item(json_data)

--- a/tests/hosting_core/app/proactive/test_conversation_builder.py
+++ b/tests/hosting_core/app/proactive/test_conversation_builder.py
@@ -5,7 +5,10 @@ Licensed under the MIT License.
 
 import pytest
 
-from microsoft_agents.hosting.core.app.proactive import Conversation, ConversationBuilder
+from microsoft_agents.hosting.core.app.proactive import (
+    Conversation,
+    ConversationBuilder,
+)
 from microsoft_agents.hosting.core.authorization import ClaimsIdentity
 
 
@@ -51,7 +54,9 @@ class TestConversationBuilderCreate:
         assert builder._agent_id == "app-id"
 
     def test_create_with_requestor_id_sets_appid_claim(self):
-        builder = ConversationBuilder.create("app-id", "msteams", requestor_id="requestor-id")
+        builder = ConversationBuilder.create(
+            "app-id", "msteams", requestor_id="requestor-id"
+        )
         assert builder._claims["appid"] == "requestor-id"
 
     def test_create_without_requestor_id_no_appid_claim(self):
@@ -199,7 +204,10 @@ class TestConversationBuilderBuild:
 
     def test_build_sets_service_url(self):
         conv = _prep_build(ConversationBuilder.create("app-id", "msteams")).build()
-        assert conv.conversation_reference.service_url == "https://smba.trafficmanager.net/teams/"
+        assert (
+            conv.conversation_reference.service_url
+            == "https://smba.trafficmanager.net/teams/"
+        )
 
     def test_build_sets_agent_with_teams_prefix(self):
         conv = _prep_build(ConversationBuilder.create("app-id", "msteams")).build()
@@ -210,6 +218,7 @@ class TestConversationBuilderBuild:
         # ConversationReference.agent has Field(None, alias="bot") with ChannelAccount type,
         # so explicitly passing bot=None raises a Pydantic ValidationError.
         from pydantic import ValidationError
+
         builder = ConversationBuilder()
         builder._channel_id = "directline"
         builder._service_url = "https://directline.botframework.com/"

--- a/tests/hosting_core/app/proactive/test_conversation_reference_builder.py
+++ b/tests/hosting_core/app/proactive/test_conversation_reference_builder.py
@@ -22,9 +22,8 @@ def _buildable(channel_id="msteams", conv_id="conv-1"):
     The implementation passes name explicitly to ChannelAccount, so an agent
     with a name must always be present before calling .build().
     """
-    return (
-        ConversationReferenceBuilder.create(channel_id, conv_id)
-        .with_agent("28:app-id", "Bot")
+    return ConversationReferenceBuilder.create(channel_id, conv_id).with_agent(
+        "28:app-id", "Bot"
     )
 
 
@@ -35,16 +34,27 @@ def _buildable(channel_id="msteams", conv_id="conv-1"):
 
 class TestServiceUrlForChannel:
     def test_teams_returns_smba_url(self):
-        assert _service_url_for_channel("msteams") == "https://smba.trafficmanager.net/teams/"
+        assert (
+            _service_url_for_channel("msteams")
+            == "https://smba.trafficmanager.net/teams/"
+        )
 
     def test_directline_returns_generic_url(self):
-        assert _service_url_for_channel("directline") == "https://directline.botframework.com/"
+        assert (
+            _service_url_for_channel("directline")
+            == "https://directline.botframework.com/"
+        )
 
     def test_webchat_returns_generic_url(self):
-        assert _service_url_for_channel("webchat") == "https://webchat.botframework.com/"
+        assert (
+            _service_url_for_channel("webchat") == "https://webchat.botframework.com/"
+        )
 
     def test_unknown_channel_uses_pattern(self):
-        assert _service_url_for_channel("mychannel") == "https://mychannel.botframework.com/"
+        assert (
+            _service_url_for_channel("mychannel")
+            == "https://mychannel.botframework.com/"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -183,11 +193,7 @@ class TestConversationReferenceBuilderBuild:
         assert ref.service_url == "https://directline.botframework.com/"
 
     def test_build_respects_explicit_service_url(self):
-        ref = (
-            _buildable()
-            .with_service_url("https://custom/")
-            .build()
-        )
+        ref = _buildable().with_service_url("https://custom/").build()
         assert ref.service_url == "https://custom/"
 
     def test_build_sets_agent_account(self):
@@ -200,11 +206,7 @@ class TestConversationReferenceBuilderBuild:
         assert ref.agent.name == "My Bot"
 
     def test_build_sets_user_account(self):
-        ref = (
-            _buildable()
-            .with_user("user-oid", "Alice")
-            .build()
-        )
+        ref = _buildable().with_user("user-oid", "Alice").build()
         assert ref.user.id == "user-oid"
         assert ref.user.name == "Alice"
 

--- a/tests/hosting_core/app/proactive/test_create_conversation_options.py
+++ b/tests/hosting_core/app/proactive/test_create_conversation_options.py
@@ -93,7 +93,9 @@ class TestCreateConversationOptionsValidate:
         opts.validate()  # must not raise
 
     def test_validate_raises_when_identity_missing(self):
-        opts = CreateConversationOptions(channel_id="msteams", parameters=_make_params())
+        opts = CreateConversationOptions(
+            channel_id="msteams", parameters=_make_params()
+        )
         with pytest.raises(ValueError, match="identity"):
             opts.validate()
 

--- a/tests/hosting_core/app/proactive/test_proactive.py
+++ b/tests/hosting_core/app/proactive/test_proactive.py
@@ -326,7 +326,9 @@ class TestProactiveContinueConversation:
 
         async def fake_continue(claims, continuation, callback):
             ctx = MagicMock()
-            with patch.object(proactive_instance, "_load_state", AsyncMock(return_value=state)):
+            with patch.object(
+                proactive_instance, "_load_state", AsyncMock(return_value=state)
+            ):
                 await callback(ctx)
 
         adapter = MagicMock()
@@ -483,7 +485,9 @@ class TestProactiveCreateConversation:
     def _make_adapter(self, new_conversation_id="new-conv"):
         ref = _make_reference(new_conversation_id)
 
-        async def fake_create(app_id, channel_id, service_url, audience, params, callback):
+        async def fake_create(
+            app_id, channel_id, service_url, audience, params, callback
+        ):
             ctx = MagicMock()
             ctx.activity.get_conversation_reference.return_value = ref
             await callback(ctx)
@@ -570,7 +574,9 @@ class TestProactiveCreateConversation:
     async def test_create_passes_channel_id_to_adapter(self, proactive, options):
         captured_channel_id = None
 
-        async def fake_create(app_id, channel_id, service_url, audience, params, callback):
+        async def fake_create(
+            app_id, channel_id, service_url, audience, params, callback
+        ):
             nonlocal captured_channel_id
             captured_channel_id = channel_id
             ref = _make_reference("x")

--- a/tests/hosting_core/telemetry/test_proactive_spans.py
+++ b/tests/hosting_core/telemetry/test_proactive_spans.py
@@ -309,7 +309,6 @@ def test_create_conversation_span_attributes(test_exporter):
 
     span = test_exporter.get_finished_spans()[0]
     assert span.attributes[attributes.ACTIVITY_CHANNEL_ID] == "msteams"
-    # members_count is serialized as a string (UNKNOWN fallback is also a string)
     assert span.attributes[attributes.MEMBERS_COUNT] == 2
 
 

--- a/tests/hosting_core/telemetry/test_proactive_spans.py
+++ b/tests/hosting_core/telemetry/test_proactive_spans.py
@@ -1,0 +1,343 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from types import SimpleNamespace
+
+from microsoft_agents.activity import (
+    Activity,
+    ChannelAccount,
+    ConversationParameters,
+)
+from microsoft_agents.hosting.core.authorization import ClaimsIdentity
+from microsoft_agents.hosting.core.telemetry import attributes
+from microsoft_agents.hosting.core.app.proactive.create_conversation_options import (
+    CreateConversationOptions,
+)
+from microsoft_agents.hosting.core.app.proactive.telemetry import constants
+from microsoft_agents.hosting.core.app.proactive.telemetry.spans import (
+    ProactiveStoreConversation,
+    ProactiveGetConversation,
+    ProactiveDeleteConversation,
+    ProactiveSendActivity,
+    ProactiveContinueConversation,
+    ProactiveCreateConversation,
+)
+
+from tests._common.fixtures.telemetry import (  # noqa: F401 — fixture imports
+    test_telemetry,
+    test_exporter,
+    test_metric_reader,
+)
+
+
+def _make_activity(activity_type="message", channel_id="msteams"):
+    return Activity(type=activity_type, channel_id=channel_id)
+
+
+_MEMBERS_SENTINEL = object()
+
+
+def _make_create_options(
+    channel_id="msteams",
+    members=_MEMBERS_SENTINEL,
+    parameters_present=True,
+):
+    params = None
+    if parameters_present:
+        if members is _MEMBERS_SENTINEL:
+            params = ConversationParameters()
+        else:
+            params = ConversationParameters(members=members)
+    return CreateConversationOptions(
+        identity=ClaimsIdentity(claims={"aud": "app-id"}, is_authenticated=True),
+        channel_id=channel_id,
+        parameters=params,
+        service_url="https://smba.trafficmanager.net/teams/",
+    )
+
+
+# ---------------------------------------------------------------------------
+# ProactiveStoreConversation
+# ---------------------------------------------------------------------------
+
+
+def test_store_conversation_creates_span(test_exporter):
+    with ProactiveStoreConversation("conv-1"):
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == constants.SPAN_STORE_CONVERSATION
+
+
+def test_store_conversation_span_attributes(test_exporter):
+    with ProactiveStoreConversation("conv-1"):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == "conv-1"
+
+
+def test_store_conversation_empty_id_falls_back_to_unknown(test_exporter):
+    with ProactiveStoreConversation(""):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == attributes.UNKNOWN
+
+
+def test_store_conversation_none_id_falls_back_to_unknown(test_exporter):
+    with ProactiveStoreConversation(None):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == attributes.UNKNOWN
+
+
+def test_store_conversation_records_span_even_on_exception(test_exporter):
+    try:
+        with ProactiveStoreConversation("conv-err"):
+            raise ValueError("storage exploded")
+    except ValueError:
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes[attributes.CONVERSATION_ID] == "conv-err"
+
+
+# ---------------------------------------------------------------------------
+# ProactiveGetConversation
+# ---------------------------------------------------------------------------
+
+
+def test_get_conversation_creates_span(test_exporter):
+    with ProactiveGetConversation("conv-1"):
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == constants.SPAN_GET_CONVERSATION
+
+
+def test_get_conversation_span_attributes_without_share(test_exporter):
+    """When share() is never called, CONVERSATION_FOUND defaults to UNKNOWN."""
+    with ProactiveGetConversation("conv-1"):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == "conv-1"
+    assert span.attributes[attributes.CONVERSATION_FOUND] == attributes.UNKNOWN
+
+
+def test_get_conversation_share_found_true(test_exporter):
+    with ProactiveGetConversation("conv-1") as span:
+        span.share(True)
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_FOUND] is True
+
+
+def test_get_conversation_share_found_false(test_exporter):
+    """Specifically guards against the `bool if ... is not None` check:
+    False must not be coerced to UNKNOWN."""
+    with ProactiveGetConversation("conv-1") as span:
+        span.share(False)
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_FOUND] is False
+
+
+def test_get_conversation_empty_id_falls_back_to_unknown(test_exporter):
+    with ProactiveGetConversation(""):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == attributes.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# ProactiveDeleteConversation
+# ---------------------------------------------------------------------------
+
+
+def test_delete_conversation_creates_span(test_exporter):
+    with ProactiveDeleteConversation("conv-1"):
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == constants.SPAN_DELETE_CONVERSATION
+
+
+def test_delete_conversation_span_attributes(test_exporter):
+    with ProactiveDeleteConversation("conv-del"):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == "conv-del"
+
+
+def test_delete_conversation_empty_id_falls_back_to_unknown(test_exporter):
+    with ProactiveDeleteConversation(""):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == attributes.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# ProactiveSendActivity
+# ---------------------------------------------------------------------------
+
+
+def test_send_activity_creates_span(test_exporter):
+    with ProactiveSendActivity("conv-1", _make_activity()):
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == constants.SPAN_SEND_ACTIVITY
+
+
+def test_send_activity_span_attributes(test_exporter):
+    activity = _make_activity(activity_type="message", channel_id="webchat")
+    with ProactiveSendActivity("conv-1", activity):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == "conv-1"
+    assert span.attributes[attributes.ACTIVITY_TYPE] == "message"
+    assert span.attributes[attributes.ACTIVITY_CHANNEL_ID] == "webchat"
+
+
+def test_send_activity_missing_activity_type_falls_back_to_unknown(test_exporter):
+    # Activity model requires `type`, so use a stand-in object that exposes the
+    # same attribute surface the span reads.
+    activity = SimpleNamespace(type=None, channel_id="msteams")
+    with ProactiveSendActivity("conv-1", activity):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.ACTIVITY_TYPE] == attributes.UNKNOWN
+
+
+def test_send_activity_missing_channel_id_falls_back_to_unknown(test_exporter):
+    activity = SimpleNamespace(type="message", channel_id=None)
+    with ProactiveSendActivity("conv-1", activity):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.ACTIVITY_CHANNEL_ID] == attributes.UNKNOWN
+
+
+def test_send_activity_empty_conversation_id_falls_back_to_unknown(test_exporter):
+    with ProactiveSendActivity("", _make_activity()):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == attributes.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# ProactiveContinueConversation
+# ---------------------------------------------------------------------------
+
+
+def test_continue_conversation_creates_span(test_exporter):
+    with ProactiveContinueConversation("conv-1", _make_activity()):
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == constants.SPAN_CONTINUE_CONVERSATION
+
+
+def test_continue_conversation_span_attributes(test_exporter):
+    activity = _make_activity(activity_type="event", channel_id="directline")
+    with ProactiveContinueConversation("conv-cont", activity):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.CONVERSATION_ID] == "conv-cont"
+    assert span.attributes[attributes.ACTIVITY_TYPE] == "event"
+    assert span.attributes[attributes.ACTIVITY_CHANNEL_ID] == "directline"
+
+
+def test_continue_conversation_missing_activity_fields_fall_back(test_exporter):
+    activity = SimpleNamespace(type=None, channel_id=None)
+    with ProactiveContinueConversation("conv-1", activity):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.ACTIVITY_TYPE] == attributes.UNKNOWN
+    assert span.attributes[attributes.ACTIVITY_CHANNEL_ID] == attributes.UNKNOWN
+
+
+def test_continue_conversation_records_span_even_on_exception(test_exporter):
+    try:
+        with ProactiveContinueConversation("conv-err", _make_activity()):
+            raise RuntimeError("handler exploded")
+    except RuntimeError:
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes[attributes.CONVERSATION_ID] == "conv-err"
+
+
+# ---------------------------------------------------------------------------
+# ProactiveCreateConversation
+# ---------------------------------------------------------------------------
+
+
+def test_create_conversation_creates_span(test_exporter):
+    with ProactiveCreateConversation(_make_create_options()):
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == constants.SPAN_CREATE_CONVERSATION
+
+
+def test_create_conversation_span_attributes(test_exporter):
+    members = [ChannelAccount(id="u-1"), ChannelAccount(id="u-2")]
+    with ProactiveCreateConversation(
+        _make_create_options(channel_id="msteams", members=members)
+    ):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.ACTIVITY_CHANNEL_ID] == "msteams"
+    # members_count is serialized as a string (UNKNOWN fallback is also a string)
+    assert span.attributes[attributes.MEMBERS_COUNT] == 2
+
+
+def test_create_conversation_members_count_unknown_when_empty_members(test_exporter):
+    """An empty list is treated the same as missing — the `and members` clause
+    in ProactiveCreateConversation short-circuits to UNKNOWN."""
+    with ProactiveCreateConversation(_make_create_options(members=[])):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.MEMBERS_COUNT] == attributes.UNKNOWN
+
+
+def test_create_conversation_members_count_unknown_when_no_parameters(test_exporter):
+    with ProactiveCreateConversation(_make_create_options(parameters_present=False)):
+        pass
+
+    span = test_exporter.get_finished_spans()[0]
+    assert span.attributes[attributes.MEMBERS_COUNT] == attributes.UNKNOWN
+
+
+def test_create_conversation_records_span_even_on_exception(test_exporter):
+    try:
+        with ProactiveCreateConversation(_make_create_options()):
+            raise RuntimeError("create failed")
+    except RuntimeError:
+        pass
+
+    spans = test_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == constants.SPAN_CREATE_CONVERSATION

--- a/tests/hosting_core/telemetry/test_proactive_spans.py
+++ b/tests/hosting_core/telemetry/test_proactive_spans.py
@@ -309,7 +309,7 @@ def test_create_conversation_span_attributes(test_exporter):
 
     span = test_exporter.get_finished_spans()[0]
     assert span.attributes[attributes.ACTIVITY_CHANNEL_ID] == "msteams"
-    # members_count is serialized as a string (UNKNOWN fallback is also a string)
+    # members_count is recorded as an int when known; unknown falls back to attributes.UNKNOWN.
     assert span.attributes[attributes.MEMBERS_COUNT] == 2
 
 


### PR DESCRIPTION
This pull request adds detailed OpenTelemetry-based telemetry spans to the proactive conversation handling logic in the Microsoft Agents Hosting Core. The main focus is on tracking and correlating key operations (store, get, delete, send activity, continue, and create conversation) with rich contextual attributes, improving observability and diagnostics for proactive scenarios. The changes also introduce new constants and attributes to support these spans. Some minor formatting and test improvements are included as well.

**Telemetry and Observability Enhancements:**

* Introduced a new `spans` module (`proactive/telemetry/spans.py`) implementing custom span wrappers for each proactive operation (store, get, delete, send activity, continue, create conversation), capturing relevant attributes for each operation.
* Added new constants for span names in `proactive/telemetry/constants.py` to standardize span identification.
* Extended telemetry attribute definitions with `CONVERSATION_FOUND` and `MEMBERS_COUNT` in `telemetry/attributes.py` to support richer span data. [[1]](diffhunk://#diff-d24924829f5076dfacf9506db40a340c4cdb3c27460f9fa7082097d6a0f5c54eR24) [[2]](diffhunk://#diff-d24924829f5076dfacf9506db40a340c4cdb3c27460f9fa7082097d6a0f5c54eR34-R35)

**Integration with Proactive Operations:**

* Updated the main `proactive.py` logic to wrap all key operations (`store_conversation`, `get_conversation`, `delete_conversation`, `send_activity`, `continue_conversation`, and `create_conversation`) with the new telemetry spans, ensuring each operation is tracked and relevant attributes are recorded. [[1]](diffhunk://#diff-bdd3ae8dbffa361b2f9a04e381814461940e863331d56dd2aa9e8ae02b7494abR19) [[2]](diffhunk://#diff-bdd3ae8dbffa361b2f9a04e381814461940e863331d56dd2aa9e8ae02b7494abR124-R126) [[3]](diffhunk://#diff-bdd3ae8dbffa361b2f9a04e381814461940e863331d56dd2aa9e8ae02b7494abR143-R148) [[4]](diffhunk://#diff-bdd3ae8dbffa361b2f9a04e381814461940e863331d56dd2aa9e8ae02b7494abR157) [[5]](diffhunk://#diff-bdd3ae8dbffa361b2f9a04e381814461940e863331d56dd2aa9e8ae02b7494abR192-R193) [[6]](diffhunk://#diff-bdd3ae8dbffa361b2f9a04e381814461940e863331d56dd2aa9e8ae02b7494abR265) [[7]](diffhunk://#diff-bdd3ae8dbffa361b2f9a04e381814461940e863331d56dd2aa9e8ae02b7494abL270-R285) [[8]](diffhunk://#diff-bdd3ae8dbffa361b2f9a04e381814461940e863331d56dd2aa9e8ae02b7494abR321-R322)
* Enhanced the `get_conversation` span to record whether the conversation was found, using the new `CONVERSATION_FOUND` attribute.

**Minor Improvements and Test Adjustments:**

* Minor code formatting improvements and explicit line breaks in test files for better readability and consistency. [[1]](diffhunk://#diff-19462c593ca734682dfcd7990c5beb5752216d9466eae5671933d91450015f0cL72-R74) [[2]](diffhunk://#diff-19462c593ca734682dfcd7990c5beb5752216d9466eae5671933d91450015f0cL198-R202) [[3]](diffhunk://#diff-73984cd6df09ef62494abc05c0efdcbc9f76fc7990a7f11de871767aae7d5be4L8-R11) [[4]](diffhunk://#diff-73984cd6df09ef62494abc05c0efdcbc9f76fc7990a7f11de871767aae7d5be4L54-R59) [[5]](diffhunk://#diff-73984cd6df09ef62494abc05c0efdcbc9f76fc7990a7f11de871767aae7d5be4L202-R210) [[6]](diffhunk://#diff-73984cd6df09ef62494abc05c0efdcbc9f76fc7990a7f11de871767aae7d5be4R221) [[7]](diffhunk://#diff-a34372bf2a6708c6f38f339017b4afd7cd79e47feba1be4d6946f415b3b93caaL25-R26) [[8]](diffhunk://#diff-a34372bf2a6708c6f38f339017b4afd7cd79e47feba1be4d6946f415b3b93caaL38-R57) [[9]](diffhunk://#diff-a34372bf2a6708c6f38f339017b4afd7cd79e47feba1be4d6946f415b3b93caaL186-R196)
* Type annotation cleanup in `proactive.py` for clarity.