### PR TITLE
Temporal fix for build testing dependencies

### DIFF
--- a/.azdo/ci-pr.yaml
+++ b/.azdo/ci-pr.yaml
@@ -83,5 +83,5 @@ steps:
   displayName: 'Install wheels'
 
 - script: |
-    pytest
+    pytest -W "ignore:SelectableGroups dict interface is deprecated. Use select.:DeprecationWarning"
   displayName: 'Test with pytest'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -71,4 +71,4 @@ jobs:
         python -m pip install ./dist/microsoft_agents_storage_cosmos*.whl
     - name: Test with pytest
       run: |
-        pytest
+        pytest -W "ignore:SelectableGroups dict interface is deprecated. Use select.:DeprecationWarning"


### PR DESCRIPTION
This pull request makes a minor update to the test commands in the CI workflows to suppress a specific deprecation warning during pytest runs.

- CI/CD workflow updates:
  * Both `.azdo/ci-pr.yaml` and `.github/workflows/python-package.yml` have been updated to run `pytest` with a warning filter to ignore the "SelectableGroups dict interface is deprecated" DeprecationWarning. [[1]](diffhunk://#diff-50b28cd1647a6801f28c6abec92ffc548ebdd47848c528f5b9baf0791c47fd7cL86-R86) [[2]](diffhunk://#diff-ee49282f461b4c8ad179f79dd5bcdf93124561074c64a771366caf93e99b9320L74-R74)