### PR TITLE
Add starlette dependency for CVE-2026-48710 fix

### DIFF
--- a/libraries/microsoft-agents-hosting-fastapi/setup.py
+++ b/libraries/microsoft-agents-hosting-fastapi/setup.py
@@ -14,5 +14,6 @@ setup(
     install_requires=[
         f"microsoft-agents-hosting-core=={package_version}",
         "fastapi>=0.104.0",
+        "starlette>=1.0.1",  # CVE-2026-48710 fix
     ],
 )

--- a/test_samples/fastapi/requirements.txt
+++ b/test_samples/fastapi/requirements.txt
@@ -1,5 +1,6 @@
 # FastAPI sample requirements
 fastapi>=0.104.0
+starlette>=1.0.1  # CVE-2026-48710 fix
 uvicorn[standard]>=0.24.0
 python-dotenv>=1.0.0
 aiohttp>=3.8.0


### PR DESCRIPTION
This pull request addresses a security vulnerability by updating dependencies in both the main package and the sample requirements. The most important change is the addition of a minimum version requirement for `starlette` to mitigate CVE-2026-48710.

**Security and Dependency Updates:**

* [`libraries/microsoft-agents-hosting-fastapi/setup.py`](diffhunk://#diff-23a4dfb38aa47a715a019f308f69641a8bdf9894b69336e00ff3facd5c239a12R17): Added `starlette>=1.0.1` to the `install_requires` list to address CVE-2026-48710.
* [`test_samples/fastapi/requirements.txt`](diffhunk://#diff-b61f556e73cac14a8ef691fe45d017c88f59221d081defd343b74be862c8d1d9R3): Added `starlette>=1.0.1` to the sample requirements for consistency and to ensure the security fix is applied in test environments.

**Testing**
* ran `test_samples\fastapi\empty_agent.py` and tested in Teams and WebChat