### PR TITLE
Adding azure region on msal config

### DIFF
--- a/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
+++ b/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
@@ -176,6 +176,18 @@ class MsalAuth(AccessTokenProviderBase):
         return f"https://login.microsoftonline.com/{tenant_id}"
 
     @staticmethod
+    def _resolve_azure_region(config: AgentAuthConfiguration) -> str | None:
+        """Resolves the Azure regional token service (ESTS-R) to use, if configured.
+
+        Returns the configured region only when it is populated and non-whitespace,
+        otherwise None so that MSAL falls back to the global token service.
+        """
+        azure_region = getattr(config, "AZURE_REGION", None)
+        if azure_region and azure_region.strip():
+            return azure_region
+        return None
+
+    @staticmethod
     def _resolve_tenant_id(
         config: AgentAuthConfiguration, tenant_id: str | None = None
     ) -> str:
@@ -253,6 +265,7 @@ class MsalAuth(AccessTokenProviderBase):
                 client_id=self._msal_configuration.CLIENT_ID,
                 authority=authority,
                 client_credential=client_credential,
+                azure_region=MsalAuth._resolve_azure_region(self._msal_configuration),
             )
 
     def _client_rep(
@@ -379,6 +392,7 @@ class MsalAuth(AccessTokenProviderBase):
                 client_id=agent_app_instance_id,
                 authority=authority,
                 client_credential={"client_assertion": agent_token_result},
+                azure_region=MsalAuth._resolve_azure_region(self._msal_configuration),
                 # token_cache=self._token_cache,
             )
 
@@ -474,6 +488,7 @@ class MsalAuth(AccessTokenProviderBase):
                 client_id=agent_app_instance_id,
                 authority=authority,
                 client_credential={"client_assertion": agent_token},
+                azure_region=MsalAuth._resolve_azure_region(self._msal_configuration),
                 # token_cache=self._token_cache,
             )
 

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -20,6 +20,8 @@ class AgentAuthConfiguration:
     SCOPES: The scopes to request
     AUTHORITY: The authority URL for the Azure AD (if different from the default).
     ALT_BLUEPRINT_ID: An optional alternative blueprint ID used when constructing a connector client.
+    AZURE_REGION: The Azure regional token service to use for token acquisition (ESTS-R).
+        This feature is currently available to first-party applications only.
     """
 
     TENANT_ID: str | None
@@ -32,6 +34,7 @@ class AgentAuthConfiguration:
     SCOPES: list[str] | None
     AUTHORITY: str | None
     ALT_BLUEPRINT_ID: str | None
+    AZURE_REGION: str | None
     ANONYMOUS_ALLOWED: bool = False
 
     # Multi-connection support: Maintains a map of all configured connections
@@ -54,6 +57,7 @@ class AgentAuthConfiguration:
         federated_client_id: str | None = None,
         authority: str | None = None,
         scopes: list[str] | None = None,
+        azure_region: str | None = None,
         anonymous_allowed: bool = False,
         **kwargs: str,
     ):
@@ -69,6 +73,13 @@ class AgentAuthConfiguration:
             "FEDERATEDCLIENTID", None
         )
         self.SCOPES = scopes or kwargs.get("SCOPES", None)
+        # Azure regional token service. Falls back to the legacy "REGIONALAUTHORITY"
+        # configuration key when "AZUREREGION" is not provided.
+        self.AZURE_REGION = (
+            azure_region
+            or kwargs.get("AZUREREGION", None)
+            or kwargs.get("REGIONALAUTHORITY", None)
+        )
         self.ALT_BLUEPRINT_ID = kwargs.get("ALT_BLUEPRINT_NAME", None)
         self.ANONYMOUS_ALLOWED = anonymous_allowed or kwargs.get(
             "ANONYMOUS_ALLOWED", False

--- a/tests/authentication_msal/test_msal_auth.py
+++ b/tests/authentication_msal/test_msal_auth.py
@@ -213,6 +213,53 @@ class TestMsalAuthTenantResolution:
         )
 
 
+class TestMsalAuthAzureRegion:
+    """
+    Test suite for resolving the Azure regional token service (ESTS-R).
+    """
+
+    def test_resolve_azure_region_when_configured(self):
+        config = AgentAuthConfiguration(azure_region="westus")
+        assert MsalAuth._resolve_azure_region(config) == "westus"
+
+    def test_resolve_azure_region_none_when_unset(self):
+        config = AgentAuthConfiguration()
+        assert MsalAuth._resolve_azure_region(config) is None
+
+    def test_resolve_azure_region_none_when_whitespace(self):
+        config = AgentAuthConfiguration(azure_region="   ")
+        assert MsalAuth._resolve_azure_region(config) is None
+
+    def test_create_client_application_passes_azure_region(self, mocker):
+        config = AgentAuthConfiguration(
+            auth_type=AuthTypes.client_secret,
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            azure_region="westus",
+        )
+        mock_cca = mocker.patch(
+            "microsoft_agents.authentication.msal.msal_auth.ConfidentialClientApplication"
+        )
+        auth = MsalAuth(config)
+        auth._create_client_application()
+        assert mock_cca.call_args.kwargs["azure_region"] == "westus"
+
+    def test_create_client_application_azure_region_defaults_none(self, mocker):
+        config = AgentAuthConfiguration(
+            auth_type=AuthTypes.client_secret,
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+        )
+        mock_cca = mocker.patch(
+            "microsoft_agents.authentication.msal.msal_auth.ConfidentialClientApplication"
+        )
+        auth = MsalAuth(config)
+        auth._create_client_application()
+        assert mock_cca.call_args.kwargs["azure_region"] is None
+
+
 # class TestMsalAuthAgentic:
 
 #     @pytest.mark.asyncio

--- a/tests/hosting_core/test_auth_configuration.py
+++ b/tests/hosting_core/test_auth_configuration.py
@@ -75,3 +75,24 @@ class TestAuthorizationConfiguration:
         assert auth_config.CONNECTION_NAME is None
         assert auth_config.AUTHORITY is None
         assert auth_config.SCOPES is None
+        assert auth_config.AZURE_REGION is None
+
+    def test_azure_region_from_parameter(self):
+        auth_config = AgentAuthConfiguration(azure_region="westus")
+        assert auth_config.AZURE_REGION == "westus"
+
+    def test_azure_region_from_kwargs(self):
+        auth_config = AgentAuthConfiguration(AZUREREGION="eastus")
+        assert auth_config.AZURE_REGION == "eastus"
+
+    def test_azure_region_legacy_regional_authority_fallback(self):
+        # When AZUREREGION is not provided, fall back to the legacy
+        # RegionalAuthority configuration key.
+        auth_config = AgentAuthConfiguration(REGIONALAUTHORITY="westeurope")
+        assert auth_config.AZURE_REGION == "westeurope"
+
+    def test_azure_region_prefers_azure_region_over_legacy(self):
+        auth_config = AgentAuthConfiguration(
+            AZUREREGION="eastus", REGIONALAUTHORITY="westeurope"
+        )
+        assert auth_config.AZURE_REGION == "eastus"


### PR DESCRIPTION
This pull request adds support for configuring Azure regional token service (ESTS-R) in the authentication flow, allowing tokens to be acquired from a specified Azure region when configured. It introduces the `AZURE_REGION` configuration option, ensures backward compatibility with legacy configuration keys, and adds comprehensive tests for the new logic.

**Azure regional token service support:**

* Added `AZURE_REGION` as a configuration option in `AgentAuthConfiguration`, with fallback to the legacy `REGIONALAUTHORITY` key if not provided. This enables specifying the Azure region for token acquisition. [[1]](diffhunk://#diff-95d51f4d77954f159cb2ca3f096ff8f9862e4be3657f1e4f8b5370791895fd8fR23-R24) [[2]](diffhunk://#diff-95d51f4d77954f159cb2ca3f096ff8f9862e4be3657f1e4f8b5370791895fd8fR37) [[3]](diffhunk://#diff-95d51f4d77954f159cb2ca3f096ff8f9862e4be3657f1e4f8b5370791895fd8fR60) [[4]](diffhunk://#diff-95d51f4d77954f159cb2ca3f096ff8f9862e4be3657f1e4f8b5370791895fd8fR76-R82)
* Updated the `MsalAuth` class to resolve and pass the `azure_region` parameter to the MSAL ConfidentialClientApplication in all relevant authentication flows. [[1]](diffhunk://#diff-f3e673212ef75dc7b92e090cdb6682cce6dcf1a84ddcdb3bb31164041e21c39dR178-R189) [[2]](diffhunk://#diff-f3e673212ef75dc7b92e090cdb6682cce6dcf1a84ddcdb3bb31164041e21c39dR268) [[3]](diffhunk://#diff-f3e673212ef75dc7b92e090cdb6682cce6dcf1a84ddcdb3bb31164041e21c39dR395) [[4]](diffhunk://#diff-f3e673212ef75dc7b92e090cdb6682cce6dcf1a84ddcdb3bb31164041e21c39dR491)

**Testing and validation:**

* Added unit tests to verify correct resolution of `AZURE_REGION` from parameters, keyword arguments, and legacy keys, as well as to ensure the value is properly passed to the MSAL client. [[1]](diffhunk://#diff-3f5399af740cdee6cf2d870be8e26980c22159d73ec7a3f6995ce0b35b05b8a8R216-R262) [[2]](diffhunk://#diff-1a3218125c15663aa086a8711e178ffacd82bedc46fd2187adee8f54b16e590eR78-R98)