### PR TITLE
Adding connection_manager property to AgentApplication

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -199,6 +199,7 @@ class AgentApplication(Agent, Generic[StateT]):
 
         :return: The connection manager for the application.
         :rtype: :class:`microsoft_agents.hosting.core.authorization.Connections`
+        """
         return self._connection_manager
 
     @property

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -161,7 +161,9 @@ class AgentApplication(Agent, Generic[StateT]):
         # TODO: decide how to initialize the Authorization (params vs options vs kwargs)
         if authorization:
             if connection_manager:
-                logger.error("AgentApplication: connection_manager is not needed when authorization is provided.")
+                logger.error(
+                    "AgentApplication: connection_manager is not needed when authorization is provided."
+                )
                 raise ApplicationError(
                     "The `AgentApplication` does not take a `connection_manager` when `authorization` is provided."
                 )

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -187,7 +187,7 @@ class AgentApplication(Agent, Generic[StateT]):
             self._auth = Authorization(
                 storage=self._options.storage,
                 connection_manager=connection_manager,
-                handlers=options.authorization_handlers,
+                auth_handlers=options.authorization_handlers,
                 **auth_options,
             )
             self._connection_manager = connection_manager

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -76,6 +76,7 @@ class AgentApplication(Agent, Generic[StateT]):
     _route_list: _RouteList[StateT]
     _error: Optional[Callable[[TurnContext, Exception], Awaitable[None]]] = None
     _turn_state_factory: Optional[Callable[[TurnContext], StateT]] = None
+    _connection_manager: Connections
 
     def __init__(
         self,
@@ -159,7 +160,13 @@ class AgentApplication(Agent, Generic[StateT]):
 
         # TODO: decide how to initialize the Authorization (params vs options vs kwargs)
         if authorization:
+            if connection_manager:
+                logger.error("AgentApplication: connection_manager is not needed when authorization is provided.")
+                raise ApplicationError(
+                    "The `AgentApplication` does not take a `connection_manager` when `authorization` is provided."
+                )
             self._auth = authorization
+            self._connection_manager = self._auth.connection_manager
         else:
             if not connection_manager:
                 logger.error(
@@ -181,6 +188,17 @@ class AgentApplication(Agent, Generic[StateT]):
                 handlers=options.authorization_handlers,
                 **auth_options,
             )
+            self._connection_manager = connection_manager
+
+    @property
+    def connection_manager(self) -> Connections:
+        """
+        The application's connection manager.
+
+        :return: The connection manager for the application.
+        :rtype: :class:`microsoft_agents.hosting.core.app.connections.Connections`
+        """
+        return self._connection_manager
 
     @property
     def adapter(self) -> ChannelServiceAdapter:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -198,8 +198,7 @@ class AgentApplication(Agent, Generic[StateT]):
         The application's connection manager.
 
         :return: The connection manager for the application.
-        :rtype: :class:`microsoft_agents.hosting.core.app.connections.Connections`
-        """
+        :rtype: :class:`microsoft_agents.hosting.core.authorization.Connections`
         return self._connection_manager
 
     @property

--- a/tests/hosting_core/app/test_agent_application.py
+++ b/tests/hosting_core/app/test_agent_application.py
@@ -433,3 +433,50 @@ async def test_on_turn_after_turn_false_still_runs_after_activity_handler():
     await app.on_turn(StubTurnContext(_make_event_activity()))
 
     assert calls == ["event", "after"]
+
+
+# ---------------------------------------------------------------------------
+# connection_manager property and constructor guard
+# ---------------------------------------------------------------------------
+
+
+def test_init_raises_when_both_authorization_and_connection_manager_provided():
+    """Providing both authorization and connection_manager is ambiguous and should raise."""
+    with pytest.raises(ApplicationError):
+        AgentApplication[TurnState](
+            options=ApplicationOptions(storage=MemoryStorage()),
+            authorization=make_auth(),
+            connection_manager=_ConnectionManager(),
+        )
+
+
+def test_connection_manager_property_returns_manager_from_authorization():
+    """When authorization is provided, connection_manager property reflects auth's manager."""
+    cm = _ConnectionManager()
+    auth = Authorization(storage=MemoryStorage(), connection_manager=cm)
+    app = AgentApplication[TurnState](
+        options=ApplicationOptions(storage=MemoryStorage()),
+        authorization=auth,
+    )
+    assert app.connection_manager is cm
+
+
+def test_connection_manager_property_returns_directly_passed_manager():
+    """When connection_manager kwarg is used (no authorization), the property returns it."""
+    cm = _ConnectionManager()
+    app = AgentApplication[TurnState](
+        options=ApplicationOptions(storage=MemoryStorage()),
+        connection_manager=cm,
+    )
+    assert app.connection_manager is cm
+
+
+def test_init_with_connection_manager_only_creates_auth():
+    """Passing only connection_manager should auto-create an Authorization instance."""
+    cm = _ConnectionManager()
+    app = AgentApplication[TurnState](
+        options=ApplicationOptions(storage=MemoryStorage()),
+        connection_manager=cm,
+    )
+    assert app.auth is not None
+    assert app.connection_manager is cm


### PR DESCRIPTION
This pull request strengthens the handling of the `connection_manager` and `authorization` parameters in the `AgentApplication` class to prevent ambiguous configurations and improve clarity. It introduces a new property for accessing the connection manager and adds tests to verify the correct behavior.

**Enhancements to AgentApplication initialization and configuration:**

* Added a guard in the `AgentApplication` constructor to raise an error if both `authorization` and `connection_manager` are provided, preventing ambiguous application state.
* Ensured that when `authorization` is provided, the `connection_manager` is always sourced from the authorization object.
* Introduced a `connection_manager` property to the `AgentApplication` class for consistent and clear access to the connection manager. [[1]](diffhunk://#diff-a0c0028a01efc798e89b84f1bca0d4323b71753bd6f43d02800f29e66bc766a6R79) [[2]](diffhunk://#diff-a0c0028a01efc798e89b84f1bca0d4323b71753bd6f43d02800f29e66bc766a6R191-R201)

**Testing improvements:**

* Added tests to verify that providing both `authorization` and `connection_manager` raises an error, and that the `connection_manager` property returns the correct manager depending on how the application was instantiated.