### PR TITLE
Color coded log messages

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_configure_logging.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_configure_logging.py
@@ -23,24 +23,22 @@ _NAME_TO_LEVEL = {
 class ColorFormatter(logging.Formatter):
     """Custom logging formatter that adds color to log messages based on their severity level."""
 
-    BRIGHT_RED = "\033[1;31m"
-    RED = "\033[31m"
-    YELLOW = "\033[33m"
-    GREEN = "\033[32m"
-    BLUE = "\033[34m"
+    MAGENTA = "\033[1;35m"
+    RED = "\033[1;31m"
+    YELLOW = "\033[1;33m"
+    GREEN = "\033[1;32m"
+    BLUE = "\033[1;34m"
     RESET = "\033[0m"
 
-    log_format = (
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
-    )
+    log_format = "{levelcolor}%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d){reset}"
 
     FORMATS = {
-        logging.CRITICAL: f"{BRIGHT_RED}{log_format}{RESET}",
-        logging.ERROR: f"{RED}{log_format}{RESET}",
-        logging.WARNING: f"{YELLOW}{log_format}{RESET}",
-        logging.INFO: f"{GREEN}{log_format}{RESET}",
-        logging.DEBUG: f"{BLUE}{log_format}{RESET}",
-        logging.NOTSET: f"{RESET}{log_format}{RESET}",
+        logging.CRITICAL: log_format.format(levelcolor=MAGENTA, reset=RESET),
+        logging.ERROR: log_format.format(levelcolor=RED, reset=RESET),
+        logging.WARNING: log_format.format(levelcolor=YELLOW, reset=RESET),
+        logging.INFO: log_format.format(levelcolor=GREEN, reset=RESET),
+        logging.DEBUG: log_format.format(levelcolor=BLUE, reset=RESET),
+        logging.NOTSET: log_format.format(levelcolor=RESET, reset=RESET),
     }
 
     def format(self, record):

--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_configure_logging.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_configure_logging.py
@@ -21,7 +21,7 @@ _NAME_TO_LEVEL = {
 
 
 class ColorFormatter(logging.Formatter):
-    """Custom logging formatter that adds color to log messages based on their severity level."""
+    """Logging formatter that can add ANSI color based on severity."""
 
     MAGENTA = "\033[1;35m"
     RED = "\033[1;31m"
@@ -30,22 +30,32 @@ class ColorFormatter(logging.Formatter):
     BLUE = "\033[1;34m"
     RESET = "\033[0m"
 
-    log_format = "{levelcolor}%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d){reset}"
+    FMT = (
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+    )
 
-    FORMATS = {
-        logging.CRITICAL: log_format.format(levelcolor=MAGENTA, reset=RESET),
-        logging.ERROR: log_format.format(levelcolor=RED, reset=RESET),
-        logging.WARNING: log_format.format(levelcolor=YELLOW, reset=RESET),
-        logging.INFO: log_format.format(levelcolor=GREEN, reset=RESET),
-        logging.DEBUG: log_format.format(levelcolor=BLUE, reset=RESET),
-        logging.NOTSET: log_format.format(levelcolor=RESET, reset=RESET),
-    }
+    def __init__(
+        self,
+        use_colors: bool = True,
+    ) -> None:
+        super().__init__(fmt=self.FMT)
+        self._plain_formatter = logging.Formatter(fmt=self.FMT)
+        if not use_colors:
+            self._formatters: dict[int, logging.Formatter] = {}
+            return
+        self._formatters = {
+            logging.CRITICAL: logging.Formatter(
+                f"{self.MAGENTA}{self.FMT}{self.RESET}"
+            ),
+            logging.ERROR: logging.Formatter(f"{self.RED}{self.FMT}{self.RESET}"),
+            logging.WARNING: logging.Formatter(f"{self.YELLOW}{self.FMT}{self.RESET}"),
+            logging.INFO: logging.Formatter(f"{self.GREEN}{self.FMT}{self.RESET}"),
+            logging.DEBUG: logging.Formatter(f"{self.BLUE}{self.FMT}{self.RESET}"),
+        }
 
-    def format(self, record):
-        """Formats the log record with color based on its severity level."""
-        log_fmt = self.FORMATS.get(record.levelno, self.FORMATS[logging.NOTSET])
-        formatter = logging.Formatter(log_fmt)
-        return formatter.format(record)
+    def format(self, record: logging.LogRecord) -> str:
+        formatter = self._formatters.get(record.levelno)
+        return (formatter or self._plain_formatter).format(record)
 
 
 def _configure_logging(logging_config: dict):
@@ -58,7 +68,9 @@ def _configure_logging(logging_config: dict):
     log_levels = logging_config.get("LOGLEVEL", {})
 
     console_handler = logging.StreamHandler()
-    console_handler.setFormatter(ColorFormatter())
+    console_handler.setFormatter(
+        ColorFormatter(use_colors=console_handler.stream.isatty())
+    )
 
     for key in log_levels:
         level_name = log_levels[key].upper()

--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_configure_logging.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_configure_logging.py
@@ -20,6 +20,36 @@ _NAME_TO_LEVEL = {
 }
 
 
+class ColorFormatter(logging.Formatter):
+    """Custom logging formatter that adds color to log messages based on their severity level."""
+
+    BRIGHT_RED = "\033[1;31m"
+    RED = "\033[31m"
+    YELLOW = "\033[33m"
+    GREEN = "\033[32m"
+    BLUE = "\033[34m"
+    RESET = "\033[0m"
+
+    log_format = (
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
+    )
+
+    FORMATS = {
+        logging.CRITICAL: f"{BRIGHT_RED}{log_format}{RESET}",
+        logging.ERROR: f"{RED}{log_format}{RESET}",
+        logging.WARNING: f"{YELLOW}{log_format}{RESET}",
+        logging.INFO: f"{GREEN}{log_format}{RESET}",
+        logging.DEBUG: f"{BLUE}{log_format}{RESET}",
+        logging.NOTSET: f"{RESET}{log_format}{RESET}",
+    }
+
+    def format(self, record):
+        """Formats the log record with color based on its severity level."""
+        log_fmt = self.FORMATS.get(record.levelno, self.FORMATS[logging.NOTSET])
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
+
+
 def _configure_logging(logging_config: dict):
     """Configures logging based on the provided logging configuration dictionary.
 
@@ -30,11 +60,7 @@ def _configure_logging(logging_config: dict):
     log_levels = logging_config.get("LOGLEVEL", {})
 
     console_handler = logging.StreamHandler()
-    console_handler.setFormatter(
-        logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
-        )
-    )
+    console_handler.setFormatter(ColorFormatter())
 
     for key in log_levels:
         level_name = log_levels[key].upper()
@@ -50,6 +76,7 @@ def _configure_logging(logging_config: dict):
         else:
             logger = logging.getLogger(namespace)
 
+        logger.propagate = False  # Prevent log messages from being propagated
         logger.handlers.clear()  # Remove existing handlers to prevent duplicates
         logger.addHandler(console_handler)
         logger.setLevel(level)


### PR DESCRIPTION
This feature adds color coded logging to the logger initialized by `load_configuration_from_env`. See the image below to see the color coding:

<img width="530" height="65" alt="image" src="https://github.com/user-attachments/assets/66d993d3-49fd-4645-a355-466b30282737" />


Closes: #438 