### PR TITLE
Activity methods type handling

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/activity.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/activity.py
@@ -676,7 +676,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         """
         Converts an entity to a specific entity type.
 
-        :param entity: The entity to convert.
+        :param raw_entity: The entity to convert.
         :param entity_cls: The class of the entity type to convert to.
         :return: The converted entity of the specified type.
         """
@@ -691,7 +691,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         """
         Converts a list of entities to a list of a specific entity type.
 
-        :param entities: The list of entities to convert.
+        :param raw_entities: The list of entities to convert.
         :param entity_cls: The class of the entity type to convert to.
         :return: The list of converted entities of the specified type.
         """

--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/activity.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/activity.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import logging
 from copy import copy
 from datetime import datetime, timezone
-from typing import Optional, Any, Self, cast, Annotated, TypeVar
+from typing import Optional, Any, cast, Annotated, TypeVar
+from typing_extensions import Self
 
 from pydantic import (
     Field,
@@ -525,7 +526,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
                 ),
                 reply_to_id=(
                     SkipNone(self.id)
-                    if type != ActivityTypes.conversation_update
+                    if self.type != ActivityTypes.conversation_update
                     or self.channel_id not in ["directline", "webchat"]
                     else None
                 ),
@@ -577,7 +578,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
                 ),
                 reply_to_id=(
                     SkipNone(self.id)  # preserve unset
-                    if type != ActivityTypes.conversation_update
+                    if self.type != ActivityTypes.conversation_update
                     or self.channel_id not in ["directline", "webchat"]
                     else None
                 ),
@@ -676,7 +677,8 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         Converts an entity to a specific entity type.
 
         :param entity: The entity to convert.
-        :return: The specified entity type.
+        :param entity_cls: The class of the entity type to convert to.
+        :return: The converted entity of the specified type.
         """
         if isinstance(raw_entity, entity_cls):
             return raw_entity
@@ -690,7 +692,8 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         Converts a list of entities to a list of a specific entity type.
 
         :param entities: The list of entities to convert.
-        :return: A list of the specified entity type.
+        :param entity_cls: The class of the entity type to convert to.
+        :return: The list of converted entities of the specified type.
         """
 
         entities: list[_EntityT] = []

--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/activity.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/activity.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from copy import copy
 from datetime import datetime, timezone
-from typing import Optional, Any
+from typing import Optional, Any, Self, cast, Annotated, TypeVar
 
 from pydantic import (
     Field,
@@ -47,6 +47,8 @@ from ._type_aliases import NonEmptyString
 from microsoft_agents.activity.errors import activity_errors
 
 logger = logging.getLogger(__name__)
+
+_EntityT = TypeVar("_EntityT", bound=Entity)
 
 
 # TODO: A2A Agent 2 is responding with None as id, had to mark it as optional (investigate)
@@ -157,7 +159,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
     local_timestamp: datetime = None
     local_timezone: NonEmptyString = None
     service_url: NonEmptyString = None
-    from_property: ChannelAccount = Field(None, alias="from")
+    from_property: Annotated[ChannelAccount, Field(alias="from")] = None
     conversation: ConversationAccount = None
     recipient: ChannelAccount = None
     text_format: NonEmptyString = None
@@ -509,33 +511,36 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         .. remarks::
             The new activity sets up routing information based on this activity.
         """
-        return pick_model(
-            Activity,
-            type=ActivityTypes.message,
-            timestamp=datetime.now(timezone.utc),
-            from_property=SkipNone(
-                ChannelAccount.pick_properties(self.recipient, ["id", "name"])
+        return cast(
+            Self,
+            pick_model(
+                self.__class__,
+                type=ActivityTypes.message,
+                timestamp=datetime.now(timezone.utc),
+                from_property=SkipNone(
+                    ChannelAccount.pick_properties(self.recipient, ["id", "name"])
+                ),
+                recipient=SkipNone(
+                    ChannelAccount.pick_properties(self.from_property, ["id", "name"])
+                ),
+                reply_to_id=(
+                    SkipNone(self.id)
+                    if type != ActivityTypes.conversation_update
+                    or self.channel_id not in ["directline", "webchat"]
+                    else None
+                ),
+                service_url=self.service_url,
+                channel_id=self.channel_id,
+                conversation=SkipNone(
+                    ConversationAccount.pick_properties(
+                        self.conversation, ["is_group", "id", "name"]
+                    )
+                ),
+                text=text if text else "",
+                locale=locale if locale else SkipNone(self.locale),
+                attachments=[],
+                entities=[],
             ),
-            recipient=SkipNone(
-                ChannelAccount.pick_properties(self.from_property, ["id", "name"])
-            ),
-            reply_to_id=(
-                SkipNone(self.id)
-                if type != ActivityTypes.conversation_update
-                or self.channel_id not in ["directline", "webchat"]
-                else None
-            ),
-            service_url=self.service_url,
-            channel_id=self.channel_id,
-            conversation=SkipNone(
-                ConversationAccount.pick_properties(
-                    self.conversation, ["is_group", "id", "name"]
-                )
-            ),
-            text=text if text else "",
-            locale=locale if locale else SkipNone(self.locale),
-            attachments=[],
-            entities=[],
         )
 
     def create_trace(
@@ -558,33 +563,36 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         if not value_type and value:
             value_type = type(value).__name__
 
-        return pick_model(
-            Activity,
-            type=ActivityTypes.trace,
-            timestamp=datetime.now(timezone.utc),
-            from_property=SkipNone(
-                ChannelAccount.pick_properties(self.recipient, ["id", "name"])
+        return cast(
+            Self,
+            pick_model(
+                self.__class__,
+                type=ActivityTypes.trace,
+                timestamp=datetime.now(timezone.utc),
+                from_property=SkipNone(
+                    ChannelAccount.pick_properties(self.recipient, ["id", "name"])
+                ),
+                recipient=SkipNone(
+                    ChannelAccount.pick_properties(self.from_property, ["id", "name"])
+                ),
+                reply_to_id=(
+                    SkipNone(self.id)  # preserve unset
+                    if type != ActivityTypes.conversation_update
+                    or self.channel_id not in ["directline", "webchat"]
+                    else None
+                ),
+                service_url=self.service_url,
+                channel_id=self.channel_id,
+                conversation=SkipNone(
+                    ConversationAccount.pick_properties(
+                        self.conversation, ["is_group", "id", "name"]
+                    )
+                ),
+                name=SkipNone(name),
+                label=SkipNone(label),
+                value_type=SkipNone(value_type),
+                value=SkipNone(value),
             ),
-            recipient=SkipNone(
-                ChannelAccount.pick_properties(self.from_property, ["id", "name"])
-            ),
-            reply_to_id=(
-                SkipNone(self.id)  # preserve unset
-                if type != ActivityTypes.conversation_update
-                or self.channel_id not in ["directline", "webchat"]
-                else None
-            ),
-            service_url=self.service_url,
-            channel_id=self.channel_id,
-            conversation=SkipNone(
-                ConversationAccount.pick_properties(
-                    self.conversation, ["is_group", "id", "name"]
-                )
-            ),
-            name=SkipNone(name),
-            label=SkipNone(label),
-            value_type=SkipNone(value_type),
-            value=SkipNone(value),
         ).as_trace_activity()
 
     @staticmethod
@@ -593,7 +601,7 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         value: object = None,
         value_type: str | None = None,
         label: str | None = None,
-    ):
+    ) -> Activity:
         """
         Creates an instance of the :class:`microsoft_agents.activity.Activity` class as a TraceActivity object.
 
@@ -607,13 +615,16 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         if not value_type and value:
             value_type = type(value).__name__
 
-        return pick_model(
+        return cast(
             Activity,
-            type=ActivityTypes.trace,
-            name=name,
-            label=SkipNone(label),
-            value_type=SkipNone(value_type),
-            value=SkipNone(value),
+            pick_model(
+                Activity,
+                type=ActivityTypes.trace,
+                name=name,
+                label=SkipNone(label),
+                value_type=SkipNone(value_type),
+                value=SkipNone(value),
+            ),
         )
 
     @staticmethod
@@ -636,25 +647,56 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
             Composite values are split only on the first ``:``.
         :returns: A conversation reference for the conversation that contains this activity.
         """
-        return pick_model(
+        return cast(
             ConversationReference,
-            activity_id=(
-                SkipNone(self.id)
-                if self.type != ActivityTypes.conversation_update
-                or self.channel_id not in ["directline", "webchat"]
-                else None
+            pick_model(
+                ConversationReference,
+                activity_id=(
+                    SkipNone(self.id)
+                    if self.type != ActivityTypes.conversation_update
+                    or self.channel_id not in ["directline", "webchat"]
+                    else None
+                ),
+                user=copy(self.from_property),
+                agent=copy(self.recipient),
+                conversation=copy(self.conversation),
+                channel_id=(
+                    self.channel_id.split(":", 1)[0]
+                    if force_base_channel and self.channel_id is not None
+                    else self.channel_id
+                ),
+                locale=self.locale,
+                service_url=self.service_url,
             ),
-            user=copy(self.from_property),
-            agent=copy(self.recipient),
-            conversation=copy(self.conversation),
-            channel_id=(
-                self.channel_id.split(":", 1)[0]
-                if force_base_channel and self.channel_id is not None
-                else self.channel_id
-            ),
-            locale=self.locale,
-            service_url=self.service_url,
         )
+
+    @staticmethod
+    def _convert_entity(raw_entity: Entity, entity_cls: type[_EntityT]) -> _EntityT:
+        """
+        Converts an entity to a specific entity type.
+
+        :param entity: The entity to convert.
+        :return: The specified entity type.
+        """
+        if isinstance(raw_entity, entity_cls):
+            return raw_entity
+        return entity_cls.model_validate(raw_entity.model_dump())
+
+    @staticmethod
+    def _convert_entity_list(
+        raw_entities: list[Entity], entity_cls: type[_EntityT]
+    ) -> list[_EntityT]:
+        """
+        Converts a list of entities to a list of a specific entity type.
+
+        :param entities: The list of entities to convert.
+        :return: A list of the specified entity type.
+        """
+
+        entities: list[_EntityT] = []
+        for e in raw_entities:
+            entities.append(Activity._convert_entity(e, entity_cls))
+        return entities
 
     def get_product_info_entity(self) -> Optional[ProductInfo]:
         if not self.entities:
@@ -662,7 +704,12 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         target = EntityTypes.PRODUCT_INFO.lower()
         # validated entities can be Entity, and that prevents us from
         # making assumptions about the casing of the 'type' attribute
-        return next(filter(lambda e: e.type.lower() == target, self.entities), None)
+        raw_product_info = next(
+            filter(lambda e: e.type.lower() == target, self.entities), None
+        )
+        if raw_product_info is None:
+            return None
+        return Activity._convert_entity(raw_product_info, ProductInfo)
 
     def get_mentions(self) -> list[Mention]:
         """
@@ -676,7 +723,11 @@ class Activity(AgentsModel, _ChannelIdFieldMixin):
         """
         if not self.entities:
             return []
-        return [x for x in self.entities if x.type.lower() == EntityTypes.MENTION]
+        raw_mentions = [
+            x for x in self.entities if x.type.lower() == EntityTypes.MENTION
+        ]
+
+        return Activity._convert_entity_list(raw_mentions, Mention)
 
     def get_reply_conversation_reference(
         self, reply: ResourceResponse

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -463,29 +463,31 @@ class AgentApplication(Agent, Generic[StateT]):
         :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
+        update_type = type.value if isinstance(type, ConversationUpdateTypes) else type
+
         def __selector(context: TurnContext):
             if context.activity.type != ActivityTypes.conversation_update:
                 return False
 
-            if type == "membersAdded":
+            if update_type == "membersAdded":
                 if isinstance(context.activity.members_added, list):
                     return len(context.activity.members_added) > 0
                 return False
 
-            if type == "membersRemoved":
+            if update_type == "membersRemoved":
                 if isinstance(context.activity.members_removed, list):
                     return len(context.activity.members_removed) > 0
                 return False
 
             if isinstance(context.activity.channel_data, object):
                 data = vars(context.activity.channel_data)
-                return data["event_type"] == type
+                return data["event_type"] == update_type
 
             return False
 
         def __call(func: RouteHandler[StateT]) -> RouteHandler[StateT]:
             logger.debug(
-                f"Registering conversation update handler for route handler {func.__name__} with type: {type} with auth handlers: {auth_handlers}"
+                f"Registering conversation update handler for route handler {func.__name__} with type: {update_type} with auth handlers: {auth_handlers}"
             )
             self.add_route(__selector, func, auth_handlers=auth_handlers, **kwargs)
             return func
@@ -517,16 +519,18 @@ class AgentApplication(Agent, Generic[StateT]):
         :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
+        reaction_type = type.value if isinstance(type, MessageReactionTypes) else type
+
         def __selector(context: TurnContext):
             if context.activity.type != ActivityTypes.message_reaction:
                 return False
 
-            if type == "reactionsAdded":
+            if reaction_type == "reactionsAdded":
                 if isinstance(context.activity.reactions_added, list):
                     return len(context.activity.reactions_added) > 0
                 return False
 
-            if type == "reactionsRemoved":
+            if reaction_type == "reactionsRemoved":
                 if isinstance(context.activity.reactions_removed, list):
                     return len(context.activity.reactions_removed) > 0
                 return False
@@ -535,7 +539,7 @@ class AgentApplication(Agent, Generic[StateT]):
 
         def __call(func: RouteHandler[StateT]) -> RouteHandler[StateT]:
             logger.debug(
-                f"Registering message reaction handler for route handler {func.__name__} with type: {type} with auth handlers: {auth_handlers}"
+                f"Registering message reaction handler for route handler {func.__name__} with type: {reaction_type} with auth handlers: {auth_handlers}"
             )
             self.add_route(__selector, func, auth_handlers=auth_handlers, **kwargs)
             return func
@@ -567,38 +571,40 @@ class AgentApplication(Agent, Generic[StateT]):
         :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
         """
 
+        update_type = type.value if isinstance(type, MessageUpdateTypes) else type
+
         def __selector(context: TurnContext):
-            if type == "editMessage":
+            if update_type == "editMessage":
                 if (
                     context.activity.type == ActivityTypes.message_update
                     and isinstance(context.activity.channel_data, dict)
                 ):
                     data = context.activity.channel_data
-                    return data["event_type"] == type
+                    return data["event_type"] == update_type
                 return False
 
-            if type == "softDeleteMessage":
+            if update_type == "softDeleteMessage":
                 if (
                     context.activity.type == ActivityTypes.message_delete
                     and isinstance(context.activity.channel_data, dict)
                 ):
                     data = context.activity.channel_data
-                    return data["event_type"] == type
+                    return data["event_type"] == update_type
                 return False
 
-            if type == "undeleteMessage":
+            if update_type == "undeleteMessage":
                 if (
                     context.activity.type == ActivityTypes.message_update
                     and isinstance(context.activity.channel_data, dict)
                 ):
                     data = context.activity.channel_data
-                    return data["event_type"] == type
+                    return data["event_type"] == update_type
                 return False
             return False
 
         def __call(func: RouteHandler[StateT]) -> RouteHandler[StateT]:
             logger.debug(
-                f"Registering message update handler for route handler {func.__name__} with type: {type} with auth handlers: {auth_handlers}"
+                f"Registering message update handler for route handler {func.__name__} with type: {update_type} with auth handlers: {auth_handlers}"
             )
             self.add_route(__selector, func, auth_handlers=auth_handlers, **kwargs)
             return func

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -457,7 +457,7 @@ class AgentApplication(Agent, Generic[StateT]):
                     return True
 
         :param type: Conversation update category that must match the incoming activity.
-        :type type: microsoft_agents.activity.ConversationUpdateTypes
+        :type type: microsoft_agents.activity.ConversationUpdateTypes | str
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
         :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
@@ -511,7 +511,7 @@ class AgentApplication(Agent, Generic[StateT]):
                     return True
 
         :param type: Reaction category that must match the incoming activity.
-        :type type: microsoft_agents.activity.MessageReactionTypes
+        :type type: microsoft_agents.activity.MessageReactionTypes | str
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
         :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.
@@ -561,7 +561,7 @@ class AgentApplication(Agent, Generic[StateT]):
                     return True
 
         :param type: Message update category that must match the incoming activity.
-        :type type: microsoft_agents.activity.MessageUpdateTypes
+        :type type: microsoft_agents.activity.MessageUpdateTypes | str
         :param auth_handlers: Optional list of authorization handler IDs for the route.
         :type auth_handlers: Optional[list[str]]
         :param kwargs: Additional route configuration passed to :meth:`microsoft_agents.hosting.core.AgentApplication.add_route`.

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -440,7 +440,7 @@ class AgentApplication(Agent, Generic[StateT]):
 
     def conversation_update(
         self,
-        type: ConversationUpdateTypes,
+        type: ConversationUpdateTypes | str,
         *,
         auth_handlers: Optional[list[str]] = None,
         **kwargs,
@@ -494,7 +494,7 @@ class AgentApplication(Agent, Generic[StateT]):
 
     def message_reaction(
         self,
-        type: MessageReactionTypes,
+        type: MessageReactionTypes | str,
         *,
         auth_handlers: Optional[list[str]] = None,
         **kwargs,
@@ -544,7 +544,7 @@ class AgentApplication(Agent, Generic[StateT]):
 
     def message_update(
         self,
-        type: MessageUpdateTypes,
+        type: MessageUpdateTypes | str,
         *,
         auth_handlers: Optional[list[str]] = None,
         **kwargs,

--- a/tests/activity/test_activity.py
+++ b/tests/activity/test_activity.py
@@ -403,7 +403,7 @@ class TestActivityConversationOps:
         mentions = activity.get_mentions()
         assert mentions == [
             Mention(text="Hello"),
-            Entity(type="mention", text="Another mention"),
+            Mention(text="Another mention"),
         ]
 
     @pytest.mark.parametrize(
@@ -418,8 +418,7 @@ class TestActivityConversationOps:
                     Entity(type="other"),
                     Entity(type="mention", text="Another mention"),
                 ],
-                Entity(
-                    type="ProductInfo",
+                ProductInfo(
                     id="product_123",
                 ),
             ],
@@ -442,7 +441,7 @@ class TestActivityConversationOps:
                     ),
                     Entity(type="mention", text="Another mention"),
                 ],
-                Entity(type="ProductInfo", id="product_123"),
+                ProductInfo(id="product_123"),
             ],
             [[], None],
         ],


### PR DESCRIPTION
This pull request introduces enhancements to type safety, entity handling, and test coverage in the `Activity` class and related code. The most significant changes include the addition of helper methods for entity conversion, improved return types and type annotations, and updates to tests to reflect these changes.

### Entity Conversion and Handling Improvements
* Added `_convert_entity` and `_convert_entity_list` static methods to `Activity` for converting raw entities to specific types, improving type safety and consistency when working with entities. Updated `get_product_info_entity` and `get_mentions` to use these helpers, ensuring they always return the correct types. [[1]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eR670-R712) [[2]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eL679-R730)

### Type Annotations and Type Safety
* Updated type annotations in several handler methods (`conversation_update`, `message_reaction`, `message_update`) to accept both enum types and strings, increasing flexibility. [[1]](diffhunk://#diff-a0c0028a01efc798e89b84f1bca0d4323b71753bd6f43d02800f29e66bc766a6L443-R443) [[2]](diffhunk://#diff-a0c0028a01efc798e89b84f1bca0d4323b71753bd6f43d02800f29e66bc766a6L497-R497) [[3]](diffhunk://#diff-a0c0028a01efc798e89b84f1bca0d4323b71753bd6f43d02800f29e66bc766a6L547-R547)
* Improved type annotations and return types for methods like `create_trace_activity`, and used `cast` to clarify return types in factory methods, enhancing static analysis and code clarity. [[1]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eL9-R9) [[2]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eL512-R517) [[3]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eR543) [[4]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eL561-R569) [[5]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eR595) [[6]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eL596-R604) [[7]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eL610-R627) [[8]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eL639-R652)

### Test Updates
* Updated tests in `test_activity.py` to expect the correct entity types (e.g., `Mention` and `ProductInfo` instead of generic `Entity`), reflecting the improved entity conversion logic. [[1]](diffhunk://#diff-7ced027634467957be20d27cda02e88c6ec4f947a42aa889b410ad09e0510c7fL406-R406) [[2]](diffhunk://#diff-7ced027634467957be20d27cda02e88c6ec4f947a42aa889b410ad09e0510c7fL421-R421) [[3]](diffhunk://#diff-7ced027634467957be20d27cda02e88c6ec4f947a42aa889b410ad09e0510c7fL445-R444)

### Pydantic Field Usage
* Changed the `from_property` field in `Activity` to use `Annotated` with `Field(alias="from")`, aligning with Pydantic best practices and improving field aliasing.

### Internal Refactoring
* Introduced a type variable `_EntityT` for generic entity conversion and imported additional typing utilities (`Self`, `cast`, `Annotated`, `TypeVar`) to support the new type-safe methods. [[1]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eL9-R9) [[2]](diffhunk://#diff-80288d3976c877f3a86d972b6d61bc36674e58550349c3ead0a4d45a2ba7463eR51-R52)