### PR TITLE
OAuth continuation fix

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -1059,7 +1059,9 @@ class AgentApplication(Agent, Generic[StateT]):
 
             task: asyncio.Task
 
-            activity = result.continuation_activity or context.activity.model_copy(deep=True)
+            activity = result.continuation_activity or context.activity.model_copy(
+                deep=True
+            )
             logger.info(
                 "Replaying the turn with current or saved continuation activity"
             )

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -1019,7 +1019,7 @@ class AgentApplication(Agent, Generic[StateT]):
         self, context: TurnContext, turn_state: StateT, result: _AuthInterceptResult
     ):
         """Handle the case where the turn should be skipped due to an auth intercept result."""
-        
+
         async def __replay(ctx: TurnContext, act: Activity):
 
             new_context = TurnContext(ctx)

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -1022,12 +1022,7 @@ class AgentApplication(Agent, Generic[StateT]):
 
         async def __replay(ctx: TurnContext, act: Activity):
 
-            new_context = TurnContext(ctx)
-            for key, value in ctx.turn_state.items():
-                new_context.turn_state[key] = value
-            new_context.activity = act
-
-            await self.adapter.continue_conversation_with_claims(
+            await self._adapter.continue_conversation_with_claims(
                 ctx.identity,
                 act,
                 self.on_turn,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -1061,7 +1061,7 @@ class AgentApplication(Agent, Generic[StateT]):
 
             task: asyncio.Task
 
-            activity = result.continuation_activity or context.activity
+            activity = result.continuation_activity or context.activity.model_copy(deep=True)
             logger.info(
                 "Replaying the turn with current or saved continuation activity"
             )

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -1020,26 +1020,54 @@ class AgentApplication(Agent, Generic[StateT]):
     ):
         """Handle the case where the turn should be skipped due to an auth intercept result."""
 
-        async def __replay(ctx: TurnContext, act: Activity):
+        if not context.identity:
+            logger.error(
+                "Cannot replay turn because context.identity is not set. Ensure that the adapter is configured to set the identity."
+            )
+            raise ApplicationError(
+                "Cannot replay turn because context.identity is not set. Ensure that the adapter is configured to set the identity."
+            )
+
+        async def __replay_turn(replay_context: TurnContext):
+
+            for key, val in context.turn_state.items():
+                if replay_context.turn_state.get(key, None) is None:
+                    replay_context.turn_state[key] = val
+
+            await self._on_turn(replay_context)
+
+        async def __replay(act: Activity):
 
             await self._adapter.continue_conversation_with_claims(
-                ctx.identity,
+                context.identity,
                 act,
-                self.on_turn,
+                __replay_turn,
             )
 
             context.activity = act
+
+        def __log_task_result(task: asyncio.Task):
+            try:
+                task.result()
+            except Exception as e:
+                logger.error(
+                    f"Error occurred while replaying the turn.",
+                    exc_info=True,
+                )
 
         if result.should_replay:
 
             await turn_state.save(context)
 
-            if result.continuation_activity:
-                logger.info("Replaying the turn with saved continuation activity")
-                asyncio.create_task(__replay(context, result.continuation_activity))
-            else:
-                logger.info("Replaying the turn")
-                asyncio.create_task(__replay(context, context.activity))
+            task: asyncio.Task
+
+            activity = result.continuation_activity or context.activity
+            logger.info(
+                "Replaying the turn with current or saved continuation activity"
+            )
+            task = asyncio.create_task(__replay(activity))
+            task.add_done_callback(__log_task_result)
+
         return
 
     async def _on_error(self, context: TurnContext, err: ApplicationError) -> None:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -4,6 +4,8 @@ Licensed under the MIT License.
 """
 
 from __future__ import annotations
+
+import asyncio
 import logging
 from contextlib import nullcontext
 from copy import copy
@@ -835,15 +837,26 @@ class AgentApplication(Agent, Generic[StateT]):
                         )
                         if auth_intercepts:
                             if continuation_activity:
-                                new_context = copy(context)
-                                new_context.activity = continuation_activity
+                                await turn_state.save(context)
                                 logger.info(
-                                    "Resending continuation activity %s",
+                                    "Queueing continuation activity %s",
                                     continuation_activity.text,
                                 )
-                                await self.on_turn(new_context)
+                                self._queue_auth_continuation(
+                                    context, continuation_activity
+                                )
+                            else:
                                 await turn_state.save(context)
-                            return
+                                logger.info(
+                                    "No continuation activity to queue, copying current activity"
+                                )
+                                new_context = TurnContext(context)
+                                for key, value in context.turn_state.items():
+                                    new_context.turn_state[key] = value
+                                self._queue_auth_continuation(
+                                    new_context, context.activity
+                                )
+                            return  # allows immediate sending of invoke response
 
                     logger.debug("Running before turn middleware")
                     if not await self._run_before_turn_middleware(context, turn_state):
@@ -1019,6 +1032,54 @@ class AgentApplication(Agent, Generic[StateT]):
             )
 
         return await func(context)
+
+    def _queue_auth_continuation(
+        self, context: TurnContext, continuation_activity: Activity
+    ) -> None:
+        task = asyncio.create_task(
+            self._replay_auth_continuation(context, continuation_activity)
+        )
+        task.add_done_callback(self._log_auth_continuation_failure)
+
+    async def _replay_auth_continuation(
+        self, context: TurnContext, continuation_activity: Activity
+    ) -> None:
+        adapter = context.adapter
+        claims_identity = context.identity
+
+        if claims_identity and hasattr(adapter, "continue_conversation_with_claims"):
+            oauth_scope_key = getattr(adapter, "OAUTH_SCOPE_KEY", None)
+            audience = (
+                context.turn_state.get(oauth_scope_key) if oauth_scope_key else None
+            )
+            await adapter.continue_conversation_with_claims(
+                claims_identity,
+                continuation_activity,
+                self.on_turn,
+                audience,
+            )
+            return
+
+        new_context = copy(context)
+        new_context.activity = continuation_activity
+        await self.on_turn(new_context)
+
+    @staticmethod
+    def _log_auth_continuation_failure(task: asyncio.Task) -> None:
+        if task.cancelled():
+            logger.warning("OAuth continuation replay was cancelled.")
+            return
+
+        exception = task.exception()
+        if exception:
+            logger.error(
+                "OAuth continuation replay failed.",
+                exc_info=(
+                    type(exception),
+                    exception,
+                    exception.__traceback__,
+                ),
+            )
 
     async def _on_error(self, context: TurnContext, err: ApplicationError) -> None:
         if self._error:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -1018,6 +1018,22 @@ class AgentApplication(Agent, Generic[StateT]):
     async def _handle_turn_skip(
         self, context: TurnContext, turn_state: StateT, result: _AuthInterceptResult
     ):
+        """Handle the case where the turn should be skipped due to an auth intercept result."""
+        
+        async def __replay(ctx: TurnContext, act: Activity):
+
+            new_context = TurnContext(ctx)
+            for key, value in ctx.turn_state.items():
+                new_context.turn_state[key] = value
+            new_context.activity = act
+
+            await self.adapter.continue_conversation_with_claims(
+                ctx.identity,
+                act,
+                self.on_turn,
+            )
+
+            context.activity = act
 
         if result.should_replay:
 
@@ -1025,62 +1041,11 @@ class AgentApplication(Agent, Generic[StateT]):
 
             if result.continuation_activity:
                 logger.info("Replaying the turn with saved continuation activity")
-                self._queue_auth_continuation(context, result.continuation_activity)
+                asyncio.create_task(__replay(context, result.continuation_activity))
             else:
                 logger.info("Replaying the turn")
-                new_context = TurnContext(context)
-                for key, value in context.turn_state.items():
-                    new_context.turn_state[key] = value
-                self._queue_auth_continuation(new_context, context.activity)
+                asyncio.create_task(__replay(context, context.activity))
         return
-
-    def _queue_auth_continuation(
-        self, context: TurnContext, continuation_activity: Activity
-    ) -> None:
-        task = asyncio.create_task(
-            self._replay_auth_continuation(context, continuation_activity)
-        )
-        task.add_done_callback(self._log_auth_continuation_failure)
-
-    async def _replay_auth_continuation(
-        self, context: TurnContext, continuation_activity: Activity
-    ) -> None:
-        adapter = context.adapter
-        claims_identity = context.identity
-
-        if claims_identity and hasattr(adapter, "continue_conversation_with_claims"):
-            oauth_scope_key = getattr(adapter, "OAUTH_SCOPE_KEY", None)
-            audience = (
-                context.turn_state.get(oauth_scope_key) if oauth_scope_key else None
-            )
-            await adapter.continue_conversation_with_claims(
-                claims_identity,
-                continuation_activity,
-                self.on_turn,
-                audience,
-            )
-            return
-
-        new_context = copy(context)
-        new_context.activity = continuation_activity
-        await self.on_turn(new_context)
-
-    @staticmethod
-    def _log_auth_continuation_failure(task: asyncio.Task) -> None:
-        if task.cancelled():
-            logger.warning("OAuth continuation replay was cancelled.")
-            return
-
-        exception = task.exception()
-        if exception:
-            logger.error(
-                "OAuth continuation replay failed.",
-                exc_info=(
-                    type(exception),
-                    exception,
-                    exception.__traceback__,
-                ),
-            )
 
     async def _on_error(self, context: TurnContext, err: ApplicationError) -> None:
         if self._error:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -41,13 +41,13 @@ from .app_options import ApplicationOptions
 
 from .state import TurnState
 from ..channel_service_adapter import ChannelServiceAdapter
-from .oauth import Authorization
+from .oauth.authorization import Authorization, _AuthInterceptResult
 from .typing_indicator import TypingIndicator
 from .telemetry import spans
 
 from ._type_defs import RouteHandler, RouteSelector
 from ._routes import _RouteList, _Route, RouteRank, _agentic_selector
-from .proactive import Proactive, ProactiveOptions
+from .proactive import Proactive
 
 logger = logging.getLogger(__name__)
 
@@ -829,33 +829,15 @@ class AgentApplication(Agent, Generic[StateT]):
                         ActivityTypes.invoke,
                     ]:
 
-                        (
-                            auth_intercepts,
-                            continuation_activity,
-                        ) = await self._auth._on_turn_auth_intercept(
-                            context, turn_state
+                        auth_intercept_result = (
+                            await self._auth._on_turn_auth_intercept(
+                                context, turn_state
+                            )
                         )
-                        if auth_intercepts:
-                            if continuation_activity:
-                                await turn_state.save(context)
-                                logger.info(
-                                    "Queueing continuation activity %s",
-                                    continuation_activity.text,
-                                )
-                                self._queue_auth_continuation(
-                                    context, continuation_activity
-                                )
-                            else:
-                                await turn_state.save(context)
-                                logger.info(
-                                    "No continuation activity to queue, copying current activity"
-                                )
-                                new_context = TurnContext(context)
-                                for key, value in context.turn_state.items():
-                                    new_context.turn_state[key] = value
-                                self._queue_auth_continuation(
-                                    new_context, context.activity
-                                )
+                        if auth_intercept_result.should_skip_turn:
+                            await self._handle_turn_skip(
+                                context, turn_state, auth_intercept_result
+                            )
                             return  # allows immediate sending of invoke response
 
                     logger.debug("Running before turn middleware")
@@ -1032,6 +1014,25 @@ class AgentApplication(Agent, Generic[StateT]):
             )
 
         return await func(context)
+
+    async def _handle_turn_skip(
+        self, context: TurnContext, turn_state: StateT, result: _AuthInterceptResult
+    ):
+
+        if result.should_replay:
+
+            await turn_state.save(context)
+
+            if result.continuation_activity:
+                logger.info("Replaying the turn with saved continuation activity")
+                self._queue_auth_continuation(context, result.continuation_activity)
+            else:
+                logger.info("Replaying the turn")
+                new_context = TurnContext(context)
+                for key, value in context.turn_state.items():
+                    new_context.turn_state[key] = value
+                self._queue_auth_continuation(new_context, context.activity)
+        return
 
     def _queue_auth_continuation(
         self, context: TurnContext, continuation_activity: Activity

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/agent_application.py
@@ -1020,14 +1020,6 @@ class AgentApplication(Agent, Generic[StateT]):
     ):
         """Handle the case where the turn should be skipped due to an auth intercept result."""
 
-        if not context.identity:
-            logger.error(
-                "Cannot replay turn because context.identity is not set. Ensure that the adapter is configured to set the identity."
-            )
-            raise ApplicationError(
-                "Cannot replay turn because context.identity is not set. Ensure that the adapter is configured to set the identity."
-            )
-
         async def __replay_turn(replay_context: TurnContext):
 
             for key, val in context.turn_state.items():
@@ -1044,8 +1036,6 @@ class AgentApplication(Agent, Generic[StateT]):
                 __replay_turn,
             )
 
-            context.activity = act
-
         def __log_task_result(task: asyncio.Task):
             try:
                 task.result()
@@ -1056,6 +1046,14 @@ class AgentApplication(Agent, Generic[StateT]):
                 )
 
         if result.should_replay:
+
+            if not context.identity:
+                logger.error(
+                    "Cannot replay turn because context.identity is not set. Ensure that the adapter is configured to set the identity."
+                )
+                raise ApplicationError(
+                    "Cannot replay turn because context.identity is not set. Ensure that the adapter is configured to set the identity."
+                )
 
             await turn_state.save(context)
 

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_user_authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_user_authorization.py
@@ -237,7 +237,7 @@ class _UserAuthorization(_AuthorizationHandler):
             await context.send_activity(
                 Activity(
                     type=ActivityTypes.invoke_response,
-                    value=InvokeResponse(status=200),
+                    value=InvokeResponse(status=200).model_dump(exclude_unset=True),
                 )
             )
 

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_user_authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_user_authorization.py
@@ -230,6 +230,14 @@ class _UserAuthorization(_AuthorizationHandler):
                     ).model_dump(exclude_unset=True),
                 )
             )
+        elif flow_state.tag == _FlowStateTag.COMPLETE:
+            logger.info("Sign-in flow completed successfully.")
+            await context.send_activity(
+                Activity(
+                    type=ActivityTypes.invoke_response,
+                    value=InvokeResponse(status=200),
+                )
+            )
 
     async def _sign_in(
         self,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_user_authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_user_authorization.py
@@ -230,8 +230,7 @@ class _UserAuthorization(_AuthorizationHandler):
                     ).model_dump(exclude_unset=True),
                 )
             )
-        elif flow_state.tag == _FlowStateTag.COMPLETE:
-            logger.info("Sign-in flow completed successfully.")
+        elif flow_state.tag == _FlowStateTag.COMPLETE and context.activity.type == ActivityTypes.invoke:
             await context.send_activity(
                 Activity(
                     type=ActivityTypes.invoke_response,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_user_authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_user_authorization.py
@@ -230,7 +230,10 @@ class _UserAuthorization(_AuthorizationHandler):
                     ).model_dump(exclude_unset=True),
                 )
             )
-        elif flow_state.tag == _FlowStateTag.COMPLETE and context.activity.type == ActivityTypes.invoke:
+        elif (
+            flow_state.tag == _FlowStateTag.COMPLETE
+            and context.activity.type == ActivityTypes.invoke
+        ):
             await context.send_activity(
                 Activity(
                     type=ActivityTypes.invoke_response,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
@@ -341,7 +341,7 @@ class Authorization:
                         is_invoke = context.activity.type == ActivityTypes.invoke
                         return _AuthInterceptResult(
                             should_skip_turn=is_invoke,
-                            should_replay=is_invoke,
+                            should_replay=False,
                             continuation_activity=None,
                         )
                     assert sign_in_state.continuation_activity is not None

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
@@ -318,7 +318,7 @@ class Authorization:
     ) -> _AuthInterceptResult:
         """Intercepts the turn to check for active authentication flows.
 
-        Returns an _AuthInterceptResult indicating whether the turn should be skipped and if a continuation activity is present.
+        Returns an _AuthInterceptResult indicating whether the turn should be skipped, replayed, and if a continuation activity is present.
 
         :param context: The context object for the current turn.
         :type context: :class:`microsoft_agents.hosting.core.turn_context.TurnContext`

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
@@ -321,7 +321,7 @@ class Authorization:
         Returns an _AuthInterceptResult indicating whether the turn should be skipped and if a continuation activity is present.
 
         :param context: The context object for the current turn.
-        :type context: :class:`microsoft_agents.hosting.core.turn_context.TurnContext
+        :type context: :class:`microsoft_agents.hosting.core.turn_context.TurnContext`
         :param state: The turn state for the current turn.
         :type state: :class:`microsoft_agents.hosting.core.app.state.turn_state.TurnState`
         :return: An _AuthInterceptResult indicating whether the turn should be skipped and if a continuation activity is present.

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 import logging
 from typing import Optional, Callable, Awaitable, cast
+from dataclasses import dataclass
 
 from microsoft_agents.activity import Activity, Channels, SignInConstants, TokenResponse
 from microsoft_agents.activity.activity_types import ActivityTypes
@@ -31,6 +32,15 @@ AUTHORIZATION_TYPE_MAP = {
     "agenticuserauthorization": AgenticUserAuthorization,
     "connectoruserauthorization": ConnectorUserAuthorization,
 }
+
+
+@dataclass
+class _AuthInterceptResult:
+    """Dataclass representing the result of an authentication intercept."""
+
+    should_skip_turn: bool
+    should_replay: bool
+    continuation_activity: Activity | None = None
 
 
 class Authorization:
@@ -305,20 +315,17 @@ class Authorization:
 
     async def _on_turn_auth_intercept(
         self, context: TurnContext, state: TurnState
-    ) -> tuple[bool, Optional[Activity]]:
+    ) -> _AuthInterceptResult:
         """Intercepts the turn to check for active authentication flows.
 
-        Returns true if the rest of the turn should be skipped because auth did not finish.
-        Returns false if the turn should continue processing as normal.
-        If auth completes and a new turn should be started, returns the continuation activity
-        from the cached _SignInState.
+        Returns an _AuthInterceptResult indicating whether the turn should be skipped and if a continuation activity is present.
 
         :param context: The context object for the current turn.
-        :type context: :class:`microsoft_agents.hosting.core.turn_context.TurnContext`
+        :type context: :class:`microsoft_agents.hosting.core.turn_context.TurnContext
         :param state: The turn state for the current turn.
         :type state: :class:`microsoft_agents.hosting.core.app.state.turn_state.TurnState`
-        :return: A tuple indicating whether the turn should be skipped and the continuation activity if applicable.
-        :rtype: tuple[bool, Optional[:class:`microsoft_agents.activity.Activity`]]
+        :return: An _AuthInterceptResult indicating whether the turn should be skipped and if a continuation activity is present.
+        :rtype: :class:`microsoft_agents.hosting.core.app.oauth.authorization._AuthInterceptResult`
         """
         sign_in_state = await self._load_sign_in_state(context)
 
@@ -331,17 +338,33 @@ class Authorization:
                 if sign_in_response.tag == _FlowStateTag.COMPLETE:
                     if not sign_in_state:
                         # flow just completed, no continuation activity
-                        return False, None
+                        return _AuthInterceptResult(
+                            should_skip_turn=context.activity.type
+                            == ActivityTypes.invoke,
+                            should_replay=True,
+                            continuation_activity=None,
+                        )
                     assert sign_in_state.continuation_activity is not None
                     continuation_activity = (
                         sign_in_state.continuation_activity.model_copy()
                     )
                     # flow complete, start new turn with continuation activity
-                    return True, continuation_activity
+
+                    return _AuthInterceptResult(
+                        should_skip_turn=True,
+                        should_replay=True,
+                        continuation_activity=continuation_activity,
+                    )
                 # auth flow still in progress, the turn should be skipped
-                return True, None
+                return _AuthInterceptResult(
+                    should_skip_turn=True,
+                    should_replay=False,
+                    continuation_activity=None,
+                )
         # no active auth flow, continue processing
-        return False, None
+        return _AuthInterceptResult(
+            should_skip_turn=False, should_replay=False, continuation_activity=None
+        )
 
     async def get_token(
         self, context: TurnContext, auth_handler_id: Optional[str] = None

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
@@ -338,7 +338,7 @@ class Authorization:
                 if sign_in_response.tag == _FlowStateTag.COMPLETE:
                     if not sign_in_state:
                         # flow just completed, no continuation activity
-                        is_invoke = (context.activity.type == ActivityTypes.invoke,)
+                        is_invoke = context.activity.type == ActivityTypes.invoke
                         return _AuthInterceptResult(
                             should_skip_turn=is_invoke,
                             should_replay=is_invoke,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
@@ -338,10 +338,10 @@ class Authorization:
                 if sign_in_response.tag == _FlowStateTag.COMPLETE:
                     if not sign_in_state:
                         # flow just completed, no continuation activity
+                        is_invoke = (context.activity.type == ActivityTypes.invoke,)
                         return _AuthInterceptResult(
-                            should_skip_turn=context.activity.type
-                            == ActivityTypes.invoke,
-                            should_replay=True,
+                            should_skip_turn=is_invoke,
+                            should_replay=is_invoke,
                             continuation_activity=None,
                         )
                     assert sign_in_state.continuation_activity is not None

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/transcript_logger.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/transcript_logger.py
@@ -51,7 +51,7 @@ class ConsoleTranscriptLogger(TranscriptLogger):
         if not activity:
             raise TypeError("Activity is required")
 
-        json_data = activity.model_dump_json(exclude_unset=True)
+        json_data = activity.model_dump_json()
         parsed = json.loads(json_data)
         print(json.dumps(parsed, indent=4))
 

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/transcript_logger.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/transcript_logger.py
@@ -51,7 +51,7 @@ class ConsoleTranscriptLogger(TranscriptLogger):
         if not activity:
             raise TypeError("Activity is required")
 
-        json_data = activity.model_dump_json()
+        json_data = activity.model_dump_json(exclude_unset=True)
         parsed = json.loads(json_data)
         print(json.dumps(parsed, indent=4))
 

--- a/tests/hosting_core/app/_oauth/test_authorization.py
+++ b/tests/hosting_core/app/_oauth/test_authorization.py
@@ -648,6 +648,7 @@ class TestAuthorizationUsage(TestEnv):
 
         assert not res.continuation_activity
         assert not res.should_skip_turn
+        assert not res.should_replay
 
         final_state = await authorization._load_sign_in_state(context)
 
@@ -687,6 +688,7 @@ class TestAuthorizationUsage(TestEnv):
 
         assert not res.continuation_activity
         assert res.should_skip_turn
+        assert not res.should_replay
 
         final_state = await authorization._load_sign_in_state(context)
         assert sign_in_state_eq(final_state, initial_state)
@@ -719,6 +721,7 @@ class TestAuthorizationUsage(TestEnv):
 
         assert res.continuation_activity == old_activity
         assert res.should_skip_turn
+        assert not res.should_replay
 
         final_state = await authorization._load_sign_in_state(context)
         assert sign_in_state_eq(final_state, initial_state)

--- a/tests/hosting_core/app/_oauth/test_authorization.py
+++ b/tests/hosting_core/app/_oauth/test_authorization.py
@@ -18,15 +18,12 @@ from microsoft_agents.hosting.core.app.oauth import (
     Authorization,
     AgenticUserAuthorization,
 )
-from microsoft_agents.hosting.core.app.oauth.authorization import _AuthInterceptResult
 
 from microsoft_agents.hosting.core._oauth import _FlowStateTag
 
 from microsoft_agents.hosting.core import (
     AuthHandler,
-    Storage,
     MemoryStorage,
-    TurnContext,
 )
 
 from tests._common.storage.utils import StorageBaseline

--- a/tests/hosting_core/app/_oauth/test_authorization.py
+++ b/tests/hosting_core/app/_oauth/test_authorization.py
@@ -18,6 +18,7 @@ from microsoft_agents.hosting.core.app.oauth import (
     Authorization,
     AgenticUserAuthorization,
 )
+from microsoft_agents.hosting.core.app.oauth.authorization import _AuthInterceptResult
 
 from microsoft_agents.hosting.core._oauth import _FlowStateTag
 
@@ -646,12 +647,10 @@ class TestAuthorizationUsage(TestEnv):
     ):
         await authorization._delete_sign_in_state(context)
 
-        intercepts, continuation_activity = await authorization._on_turn_auth_intercept(
-            context, None
-        )
+        res = await authorization._on_turn_auth_intercept(context, None)
 
-        assert not continuation_activity
-        assert not intercepts
+        assert not res.continuation_activity
+        assert not res.should_skip_turn
 
         final_state = await authorization._load_sign_in_state(context)
 
@@ -687,12 +686,10 @@ class TestAuthorizationUsage(TestEnv):
             context, copy_sign_in_state(initial_state)
         )
 
-        intercepts, continuation_activity = await authorization._on_turn_auth_intercept(
-            context, auth_handler_id
-        )
+        res = await authorization._on_turn_auth_intercept(context, auth_handler_id)
 
-        assert not continuation_activity
-        assert intercepts
+        assert not res.continuation_activity
+        assert res.should_skip_turn
 
         final_state = await authorization._load_sign_in_state(context)
         assert sign_in_state_eq(final_state, initial_state)
@@ -721,12 +718,10 @@ class TestAuthorizationUsage(TestEnv):
             context, copy_sign_in_state(initial_state)
         )
 
-        intercepts, continuation_activity = await authorization._on_turn_auth_intercept(
-            context, auth_handler_id
-        )
+        res = await authorization._on_turn_auth_intercept(context, auth_handler_id)
 
-        assert continuation_activity == old_activity
-        assert intercepts
+        assert res.continuation_activity == old_activity
+        assert res.should_skip_turn
 
         final_state = await authorization._load_sign_in_state(context)
         assert sign_in_state_eq(final_state, initial_state)

--- a/tests/hosting_dialogs/test_dialog_manager.py
+++ b/tests/hosting_dialogs/test_dialog_manager.py
@@ -120,17 +120,13 @@ class SimpleComponentDialog(ComponentDialog):
             if test_case != SkillFlowTestCase.root_bot_only:
                 # Create a skill ClaimsIdentity and put it in turn_state so isSkillClaim() returns True.
                 claims_identity = ClaimsIdentity({}, False)
-                claims_identity.claims[
-                    "ver"
-                ] = "2.0"  # AuthenticationConstants.VersionClaim
-                claims_identity.claims[
-                    "aud"
-                ] = (
+                claims_identity.claims["ver"] = (
+                    "2.0"  # AuthenticationConstants.VersionClaim
+                )
+                claims_identity.claims["aud"] = (
                     SimpleComponentDialog.skill_bot_id
                 )  # AuthenticationConstants.AudienceClaim
-                claims_identity.claims[
-                    "azp"
-                ] = (
+                claims_identity.claims["azp"] = (
                     SimpleComponentDialog.parent_bot_id
                 )  # AuthenticationConstants.AuthorizedParty
                 context._identity = claims_identity


### PR DESCRIPTION
This pull request introduces improvements to how OAuth continuation activities are handled and queued, adds better logging for user authorization flows, and refines activity logging in transcripts. The main changes focus on making authentication flows more robust and observable, especially in scenarios involving asynchronous operations and error handling.

**OAuth Continuation Handling and Robustness:**

* Refactored the handling of OAuth continuation activities in `agent_application.py` to use a new `_queue_auth_continuation` method. This now queues the continuation asynchronously, improving reliability and decoupling the flow from the current turn context. Errors during replay are now logged via a dedicated callback. [[1]](diffhunk://#diff-a0c0028a01efc798e89b84f1bca0d4323b71753bd6f43d02800f29e66bc766a6L838-R859) [[2]](diffhunk://#diff-a0c0028a01efc798e89b84f1bca0d4323b71753bd6f43d02800f29e66bc766a6R1036-R1083)
* Added new methods `_queue_auth_continuation`, `_replay_auth_continuation`, and `_log_auth_continuation_failure` to encapsulate the queuing, replay, and error logging of authentication continuations. This also includes proper handling for adapters with claims support.
* Imported `asyncio` to enable asynchronous task creation for continuation activities.

**User Authorization Flow Logging:**

* Improved logging in the OAuth user authorization handler to log when the sign-in flow completes successfully, and sends an appropriate invoke response to the client.

**Transcript Logging Improvements:**

* Updated the transcript logger to exclude unset fields when serializing activities to JSON, reducing unnecessary data in logs.