### PR TITLE
`Connections` and `AccessTokenProviderBase` interface improvements

### DIFF
--- a/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
+++ b/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
@@ -61,6 +61,15 @@ class MsalAuth(AccessTokenProviderBase):
             f"Initializing MsalAuth with configuration: {self._msal_configuration}"
         )
 
+    @property
+    def configuration(self) -> AgentAuthConfiguration:
+        """
+        The configuration for the access token provider.
+
+        :return: The configuration as an AgentAuthConfiguration object.
+        """
+        return self._msal_configuration
+
     async def get_access_token(
         self, resource_url: str, scopes: list[str], force_refresh: bool = False
     ) -> str:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/access_token_provider_base.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/access_token_provider_base.py
@@ -1,11 +1,23 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import Protocol, Optional
-from abc import abstractmethod
+from abc import ABC, abstractmethod
+
+from .agent_auth_configuration import AgentAuthConfiguration
 
 
-class AccessTokenProviderBase(Protocol):
+class AccessTokenProviderBase(ABC):
+
+    @property
+    @abstractmethod
+    def configuration(self) -> AgentAuthConfiguration:
+        """
+        The configuration for the access token provider.
+
+        :return: The configuration as an AgentAuthConfiguration object.
+        """
+        raise NotImplementedError()
+
     @abstractmethod
     async def get_access_token(
         self, resource_url: str, scopes: list[str], force_refresh: bool = False
@@ -18,7 +30,7 @@ class AccessTokenProviderBase(Protocol):
         :param force_refresh: True to force a refresh of the token; or false to get the token only if it is necessary.
         :return: The access token as a string.
         """
-        pass
+        raise NotImplementedError()
 
     async def acquire_token_on_behalf_of(
         self, scopes: list[str], user_assertion: str
@@ -34,7 +46,7 @@ class AccessTokenProviderBase(Protocol):
 
     async def get_agentic_application_token(
         self, tenant_id: str, agent_app_instance_id: str
-    ) -> Optional[str]:
+    ) -> str | None:
         raise NotImplementedError()
 
     async def get_agentic_instance_token(
@@ -48,5 +60,5 @@ class AccessTokenProviderBase(Protocol):
         agent_app_instance_id: str,
         agentic_user_id: str,
         scopes: list[str],
-    ) -> Optional[str]:
+    ) -> str | None:
         raise NotImplementedError()

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/anonymous_token_provider.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/anonymous_token_provider.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from .agent_auth_configuration import AgentAuthConfiguration
 from .access_token_provider_base import AccessTokenProviderBase
 
 
@@ -11,6 +12,14 @@ class AnonymousTokenProvider(AccessTokenProviderBase):
     A class that provides an anonymous token for authentication.
     This is used when no authentication is required.
     """
+
+    @property
+    def configuration(self) -> AgentAuthConfiguration:
+        """
+        The configuration for the anonymous token provider.
+        Since this provider does not require any configuration, it returns None.
+        """
+        return AgentAuthConfiguration()
 
     async def get_access_token(
         self, resource_url: str, scopes: list[str], force_refresh: bool = False

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/connection_manager.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/connection_manager.py
@@ -6,6 +6,11 @@ import logging
 
 from collections.abc import Callable
 
+from microsoft_agents.activity import (
+    Activity,
+    RoleTypes
+)
+
 from .agent_auth_configuration import AgentAuthConfiguration
 from .access_token_provider_base import AccessTokenProviderBase
 from .claims_identity import ClaimsIdentity
@@ -151,7 +156,7 @@ class ConnectionManager(Connections):
             raise ValueError(
                 f"Invalid SERVICEURL regex '{pattern}' in connections map: {exc}"
             ) from exc
-
+        
     def get_token_provider(
         self, claims_identity: ClaimsIdentity, service_url: str
     ) -> AccessTokenProviderBase:
@@ -188,6 +193,40 @@ class ConnectionManager(Connections):
 
         raise ValueError(
             f"No connection found for audience '{aud}' and serviceUrl '{service_url}'."
+        )
+    
+    def get_token_provider_from_activity(
+            self,
+            claims_identity: ClaimsIdentity,
+            activity: Activity
+            ) -> AccessTokenProviderBase:
+        """
+        Get the OAuth token provider for the agent from an activity.
+
+        :param claims_identity: The claims identity of the bot.
+        :type claims_identity: :class:`microsoft_agents.hosting.core.ClaimsIdentity`
+        :param activity: The activity of the bot.
+        :type activity: dict
+        :return: The OAuth token provider for the agent.
+        :rtype: :class:`microsoft_agents.hosting.core.AccessTokenProviderBase`
+        :raises ValueError: If no connection is found for the given audience and service URL.
+        """
+        connection: AccessTokenProviderBase | None = None
+        try:
+            connection = self.get_token_provider(claims_identity, activity.service_url)
+        finally:
+            if (connection is not None and (
+                activity.recipient.role == RoleTypes.agentic_identity or
+                activity.recipient.role == RoleTypes.agentic_user
+            )):
+                if connection.configuration.ALT_BLUEPRINT_ID:
+                    connection = self.get_connection(connection.configuration.ALT_BLUEPRINT_ID)
+                
+        if connection:
+            return connection
+        
+        raise RuntimeError(
+            "The connection returned by get_token_provider is not compatible with the activity's recipient role."
         )
 
     def get_default_connection_configuration(self) -> AgentAuthConfiguration:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/connections.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/connections.py
@@ -4,6 +4,8 @@
 from abc import abstractmethod
 from typing import Protocol
 
+from microsoft_agents.activity import Activity
+
 from .agent_auth_configuration import AgentAuthConfiguration
 from .access_token_provider_base import AccessTokenProviderBase
 from .claims_identity import ClaimsIdentity
@@ -15,6 +17,9 @@ class Connections(Protocol):
     def get_connection(self, connection_name: str) -> AccessTokenProviderBase:
         """
         Get the OAuth connection for the agent.
+
+        :param connection_name: The name of the connection.
+        :return: The OAuth connection for the agent.
         """
         raise NotImplementedError()
 
@@ -22,6 +27,8 @@ class Connections(Protocol):
     def get_default_connection(self) -> AccessTokenProviderBase:
         """
         Get the default OAuth connection for the agent.
+
+        :return: The default OAuth connection for the agent.
         """
         raise NotImplementedError()
 
@@ -31,12 +38,31 @@ class Connections(Protocol):
     ) -> AccessTokenProviderBase:
         """
         Get the OAuth token provider for the agent.
+
+        :param claims_identity: The claims identity of the agent.
+        :param service_url: The service URL of the agent.
+        :return: The OAuth token provider for the agent.
         """
         raise NotImplementedError()
+    
+    @abstractmethod
+    def get_token_provider_from_activity(
+        self, claims_identity: ClaimsIdentity, activity: Activity
+    ) -> AccessTokenProviderBase:
+        """
+        Get the OAuth token provider for the agent from an activity.
+        
+        :param claims_identity: The claims identity of the agent.
+        :param activity: The activity from which to get the token provider.
+        """
+        raise NotImplementedError(
+    )
 
     @abstractmethod
     def get_default_connection_configuration(self) -> AgentAuthConfiguration:
         """
         Get the default connection configuration for the agent.
+
+        :return: The default connection configuration for the agent.
         """
         raise NotImplementedError()

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/rest_channel_service_client_factory.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/rest_channel_service_client_factory.py
@@ -49,17 +49,9 @@ class RestChannelServiceClientFactory(ChannelServiceClientFactoryBase):
             context.identity, service_url
         )
 
-        # Provider-agnostic access to the connection's auth configuration. MSAL
-        # exposes it as ``_msal_configuration``; other providers (e.g. the Entra
-        # sidecar) expose it as ``configuration``. The only value needed here is
-        # the optional alternate-blueprint connection name.
-        configuration = getattr(connection, "_msal_configuration", None)
-        if configuration is None:
-            configuration = getattr(connection, "configuration", None)
+        configuration = connection.configuration
+        alt_blueprint_id = configuration.ALT_BLUEPRINT_ID
 
-        alt_blueprint_id = (
-            getattr(configuration, "ALT_BLUEPRINT_ID", None) if configuration else None
-        )
         if alt_blueprint_id:
             logger.debug(
                 "Using alternative blueprint ID for agentic token retrieval: %s",


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the authentication and authorization core, focusing on standardizing access to configuration, enhancing type safety, and improving the interface for retrieving access token providers. The most significant change is the addition of a unified `configuration` property to all access token providers, enabling consistent and type-safe access to provider configuration. Additionally, the codebase now supports retrieving a token provider directly from an activity, and several type annotations and interface contracts have been clarified.

### Interface and API Improvements

* Added an abstract `configuration` property to `AccessTokenProviderBase`, requiring all access token providers to expose their configuration in a consistent way.
* Implemented the `configuration` property in `MsalAuth` and `AnonymousTokenProvider`, returning the provider's configuration (or a default/empty configuration for anonymous providers). [[1]](diffhunk://#diff-f3e673212ef75dc7b92e090cdb6682cce6dcf1a84ddcdb3bb31164041e21c39dR64-R72) [[2]](diffhunk://#diff-527193576c57fce3814277b4d2734a510aed5fce0765d67bd09840d891393f5bR16-R23)
* Updated the `Connections` protocol to require a `get_token_provider_from_activity` method, allowing retrieval of a token provider based on both `ClaimsIdentity` and `Activity`.

### Type and Annotation Enhancements

* Changed return types for several methods in `AccessTokenProviderBase` from `Optional[str]` to `str | None` for improved clarity and Python 3.10+ compatibility. [[1]](diffhunk://#diff-0914013b23e0bb8d9e90b3b2e2c0ab2cf869cafdcb1831b06f72cf98240dc013L37-R49) [[2]](diffhunk://#diff-0914013b23e0bb8d9e90b3b2e2c0ab2cf869cafdcb1831b06f72cf98240dc013L51-R63)
* Improved type annotations and docstrings for connection retrieval methods, making expected parameters and return values clearer. [[1]](diffhunk://#diff-a9bd1d34079729546eb76f04f9009f99467e95967d02d30e4bab4ae240218edcR20-R31) [[2]](diffhunk://#diff-a9bd1d34079729546eb76f04f9009f99467e95967d02d30e4bab4ae240218edcR41-R66)

### Refactoring and Consistency

* Refactored `_get_agentic_token` in `rest_channel_service_client_factory.py` to use the new `configuration` property directly, removing legacy and provider-specific code paths.
* Added `get_token_provider_from_activity` method to `connection_manager.py` to select the appropriate token provider based on the recipient role and configuration, supporting alternate blueprint IDs.

These changes collectively improve maintainability, type safety, and the extensibility of the authentication core.