### PR TITLE
Quality: Incorrect type annotation for `NonEmptyString` defaulting to `None`

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/attachment_view.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/attachment_view.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+from typing import Optional
+
 from .agents_model import AgentsModel
 from ._type_aliases import NonEmptyString
 
@@ -14,5 +16,5 @@ class AttachmentView(AgentsModel):
     :type size: int
     """
 
-    view_id: NonEmptyString = None
+    view_id: Optional[NonEmptyString] = None
     size: int = None

--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/channel_account.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/channel_account.py
@@ -25,7 +25,7 @@ class ChannelAccount(AgentsModel):
 
     model_config = ConfigDict(extra="allow")
 
-    id: NonEmptyString = None
+    id: Optional[NonEmptyString] = None
     name: str = None
     aad_object_id: Optional[NonEmptyString] = None
     role: Optional[NonEmptyString] = None


### PR DESCRIPTION
## Summary

Quality: Incorrect type annotation for `NonEmptyString` defaulting to `None`

## Problem

**Severity**: `High` | **File**: `libraries/microsoft-agents-activity/microsoft_agents/activity/attachment_view.py:L19`

Across many Pydantic models (e.g., `AttachmentView`, `AttachmentInfo`, `CardImage`), fields are typed as `NonEmptyString` (which enforces `min_length=1`) but are assigned a default value of `None`. This creates a contradiction where the type says it must be a non-empty string, but the default is `None`. This will cause Pydantic validation errors if the fields are not explicitly set.

## Solution

Use `Optional[NonEmptyString] = None` or `NonEmptyString | None = None` for fields that are genuinely optional, to correctly reflect that `None` is a valid value.

## Changes

- `libraries/microsoft-agents-activity/microsoft_agents/activity/attachment_view.py` (modified)
- `libraries/microsoft-agents-activity/microsoft_agents/activity/channel_account.py` (modified)