### PR TITLE
AccessTokenProviderBase interface improvements

### DIFF
--- a/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
+++ b/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
@@ -61,6 +61,15 @@ class MsalAuth(AccessTokenProviderBase):
             f"Initializing MsalAuth with configuration: {self._msal_configuration}"
         )
 
+    @property
+    def configuration(self) -> AgentAuthConfiguration:
+        """Returns the MSAL authentication configuration.
+
+        :return: The MSAL authentication configuration.
+        :rtype: :class:`microsoft_agents.hosting.core.authorization.agent_auth_configuration.AgentAuthConfiguration`
+        """
+        return self._msal_configuration
+
     async def get_access_token(
         self, resource_url: str, scopes: list[str], force_refresh: bool = False
     ) -> str:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/access_token_provider_base.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/access_token_provider_base.py
@@ -1,11 +1,24 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import Protocol, Optional
+from typing import Protocol
 from abc import abstractmethod
+
+from .agent_auth_configuration import AgentAuthConfiguration
 
 
 class AccessTokenProviderBase(Protocol):
+
+    @property
+    @abstractmethod
+    def configuration(self) -> AgentAuthConfiguration:
+        """
+        The configuration for the access token provider.
+
+        :return: The configuration for the access token provider.
+        """
+        raise NotImplementedError()
+
     @abstractmethod
     async def get_access_token(
         self, resource_url: str, scopes: list[str], force_refresh: bool = False
@@ -34,7 +47,7 @@ class AccessTokenProviderBase(Protocol):
 
     async def get_agentic_application_token(
         self, tenant_id: str, agent_app_instance_id: str
-    ) -> Optional[str]:
+    ) -> str | None:
         raise NotImplementedError()
 
     async def get_agentic_instance_token(
@@ -48,5 +61,5 @@ class AccessTokenProviderBase(Protocol):
         agent_app_instance_id: str,
         agentic_user_id: str,
         scopes: list[str],
-    ) -> Optional[str]:
+    ) -> str | None:
         raise NotImplementedError()

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/anonymous_token_provider.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/anonymous_token_provider.py
@@ -4,6 +4,7 @@
 from typing import Optional
 
 from .access_token_provider_base import AccessTokenProviderBase
+from .agent_auth_configuration import AgentAuthConfiguration
 
 
 class AnonymousTokenProvider(AccessTokenProviderBase):
@@ -11,6 +12,14 @@ class AnonymousTokenProvider(AccessTokenProviderBase):
     A class that provides an anonymous token for authentication.
     This is used when no authentication is required.
     """
+
+    @property
+    def configuration(self) -> AgentAuthConfiguration:
+        """
+        The configuration for the access token provider.
+        :return: The configuration for the access token provider.
+        """
+        return AgentAuthConfiguration()
 
     async def get_access_token(
         self, resource_url: str, scopes: list[str], force_refresh: bool = False

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/connections.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/connections.py
@@ -15,6 +15,9 @@ class Connections(Protocol):
     def get_connection(self, connection_name: str) -> AccessTokenProviderBase:
         """
         Get the OAuth connection for the agent.
+
+        :param connection_name: The name of the connection.
+        :return: The access token provider for the agent.
         """
         raise NotImplementedError()
 
@@ -22,6 +25,8 @@ class Connections(Protocol):
     def get_default_connection(self) -> AccessTokenProviderBase:
         """
         Get the default OAuth connection for the agent.
+
+        :return: The access token provider for the agent.
         """
         raise NotImplementedError()
 
@@ -31,6 +36,10 @@ class Connections(Protocol):
     ) -> AccessTokenProviderBase:
         """
         Get the OAuth token provider for the agent.
+
+        :param claims_identity: The claims identity of the agent.
+        :param service_url: The service URL for which to get the token provider.
+        :return: The access token provider for the agent.
         """
         raise NotImplementedError()
 
@@ -38,5 +47,7 @@ class Connections(Protocol):
     def get_default_connection_configuration(self) -> AgentAuthConfiguration:
         """
         Get the default connection configuration for the agent.
+
+        :return: The default connection configuration for the agent.
         """
         raise NotImplementedError()

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/rest_channel_service_client_factory.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/rest_channel_service_client_factory.py
@@ -49,17 +49,9 @@ class RestChannelServiceClientFactory(ChannelServiceClientFactoryBase):
             context.identity, service_url
         )
 
-        # Provider-agnostic access to the connection's auth configuration. MSAL
-        # exposes it as ``_msal_configuration``; other providers (e.g. the Entra
-        # sidecar) expose it as ``configuration``. The only value needed here is
-        # the optional alternate-blueprint connection name.
-        configuration = getattr(connection, "_msal_configuration", None)
-        if configuration is None:
-            configuration = getattr(connection, "configuration", None)
+        configuration = connection.configuration
+        alt_blueprint_id = configuration.ALT_BLUEPRINT_ID
 
-        alt_blueprint_id = (
-            getattr(configuration, "ALT_BLUEPRINT_ID", None) if configuration else None
-        )
         if alt_blueprint_id:
             logger.debug(
                 "Using alternative blueprint ID for agentic token retrieval: %s",

--- a/tests/_common/testing_objects/testing_token_provider.py
+++ b/tests/_common/testing_objects/testing_token_provider.py
@@ -1,4 +1,7 @@
-from microsoft_agents.hosting.core import AccessTokenProviderBase
+from microsoft_agents.hosting.core import (
+    AccessTokenProviderBase,
+    AgentAuthConfiguration,
+)
 
 
 class TestingTokenProvider(AccessTokenProviderBase):
@@ -19,6 +22,11 @@ class TestingTokenProvider(AccessTokenProviderBase):
             name: Identifier used to generate predictable token values
         """
         self.name = name
+        self._configuration = AgentAuthConfiguration()
+
+    @property
+    def configuration(self) -> AgentAuthConfiguration:
+        return self._configuration
 
     async def get_access_token(
         self, resource_url: str, scopes: list[str], force_refresh: bool = False

--- a/tests/hosting_core/test_connection_manager.py
+++ b/tests/hosting_core/test_connection_manager.py
@@ -15,7 +15,11 @@ class FakeProvider(AccessTokenProviderBase):
     """Minimal provider that records the configuration it was built from."""
 
     def __init__(self, configuration: AgentAuthConfiguration):
-        self.configuration = configuration
+        self._configuration = configuration
+
+    @property
+    def configuration(self) -> AgentAuthConfiguration:
+        return self._configuration
 
     async def get_access_token(self, resource_url, scopes, force_refresh=False):
         return "fake-token"

--- a/tests/hosting_core/test_rest_channel_service_client_factory.py
+++ b/tests/hosting_core/test_rest_channel_service_client_factory.py
@@ -292,7 +292,7 @@ class TestRestChannelServiceClientFactory:
         if alt_blueprint:
             auth_config.ALT_BLUEPRINT_ID = "alt_blueprint_id"
             connection_manager.get_connection = mocker.Mock(return_value=token_provider)
-        token_provider._msal_configuration = auth_config
+        token_provider.configuration = auth_config
 
         factory = RestChannelServiceClientFactory(connection_manager)
 
@@ -383,8 +383,8 @@ class TestRestChannelServiceClientFactory:
     async def test_create_connector_client_agentic_no_configuration(
         self, mocker, activity_agentic_identity
     ):
-        """A provider exposing neither config attribute must not raise; it should
-        simply skip the alternate-blueprint redirect."""
+        """A provider without an alternate blueprint configured must not raise; it
+        should simply skip the alternate-blueprint redirect."""
         # setup
         mock_connector_client = mocker.Mock(spec=TeamsConnectorClient)
         mocker.patch.object(
@@ -397,6 +397,7 @@ class TestRestChannelServiceClientFactory:
         token_provider.get_agentic_instance_token = mocker.AsyncMock(
             return_value=(DEFAULTS.token, DEFAULTS.token)
         )
+        token_provider.configuration = AgentAuthConfiguration()
 
         connection_manager = mocker.Mock(spec=Connections)
         connection_manager.get_token_provider = mocker.Mock(return_value=token_provider)
@@ -447,7 +448,7 @@ class TestRestChannelServiceClientFactory:
         if alt_blueprint:
             auth_config.ALT_BLUEPRINT_ID = "alt_blueprint_id"
             connection_manager.get_connection = mocker.Mock(return_value=token_provider)
-        token_provider._msal_configuration = auth_config
+        token_provider.configuration = auth_config
 
         factory = RestChannelServiceClientFactory(connection_manager)
 


### PR DESCRIPTION
This pull request introduces a standardized way to access authentication configuration across all access token providers by adding a `configuration` property to the `AccessTokenProviderBase` protocol and implementing it in relevant classes. It also updates type hints for better clarity and adds or improves docstrings for several methods.

### Authentication Configuration Standardization

* Added an abstract `configuration` property to the `AccessTokenProviderBase` protocol, ensuring all access token providers expose their configuration in a consistent way.
* Implemented the `configuration` property in `MsalAuth` and `AnonymousTokenProvider` to return their respective `AgentAuthConfiguration` instances. [[1]](diffhunk://#diff-f3e673212ef75dc7b92e090cdb6682cce6dcf1a84ddcdb3bb31164041e21c39dR64-R72) [[2]](diffhunk://#diff-527193576c57fce3814277b4d2734a510aed5fce0765d67bd09840d891393f5bR16-R23)
* Refactored code in `rest_channel_service_client_factory.py` to use the new `configuration` property directly, simplifying and unifying access to provider configuration.

### Type Hint and Documentation Improvements

* Updated return type hints for token retrieval methods to use `str | None` instead of `Optional[str]` for clarity and modern Python style. [[1]](diffhunk://#diff-0914013b23e0bb8d9e90b3b2e2c0ab2cf869cafdcb1831b06f72cf98240dc013L37-R50) [[2]](diffhunk://#diff-0914013b23e0bb8d9e90b3b2e2c0ab2cf869cafdcb1831b06f72cf98240dc013L51-R64)
* Enhanced docstrings for methods in `connections.py` to clarify parameters and return values. [[1]](diffhunk://#diff-a9bd1d34079729546eb76f04f9009f99467e95967d02d30e4bab4ae240218edcR18-R29) [[2]](diffhunk://#diff-a9bd1d34079729546eb76f04f9009f99467e95967d02d30e4bab4ae240218edcR39-R51)