### PR TITLE
update black version for precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 22.3.0 # Use the latest stable version of Black
+  rev: 26.5.1 # Use the latest stable version of Black
   hooks:
   - id: black
     args: [--line-length=88] # Adjust line length as needed


### PR DESCRIPTION
If precommit hooks are used and checks are run, the ci pipeline will fail because of the mismatched versions of black (the ci pipeline using the latest release). This pr updates that so the formatting is consistent to what is expected