### PR TITLE
Supporting RestChannelServiceClientFactory configuration from ChannelAdapter constructor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# Microsoft 365 Agents SDK for Python - Release Notes v1.4.0 (Unreleased)
+
+## New Models & APIs
+- **Regionalized UserTokenClient Support**: Added optional argument to `CloudAdapter` to configure Token Service endpoint used by `RestChannelServiceClientFactory` when creating `UserTokenClient` instances. 
+
 # Microsoft 365 Agents SDK for Python - Release Notes v1.3.0
 
 **Release Date:** 2026-07-30

--- a/dev/integration/tests/adapter/test_aiohttp_cloud_adapter.py
+++ b/dev/integration/tests/adapter/test_aiohttp_cloud_adapter.py
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import cast
+
+import pytest
+
+from microsoft_agents.activity import Activity, ConversationAccount
+from microsoft_agents.hosting.aiohttp import CloudAdapter
+from microsoft_agents.hosting.core import TurnContext
+from microsoft_agents.hosting.core.authorization import ClaimsIdentity, Connections
+from microsoft_agents.hosting.core.connector.client import UserTokenClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "token_service_endpoint",
+    [
+        "https://europe.api.botframework.com",
+        "https://unitedstates.api.botframework.com",
+        "https://india.api.botframework.com",
+    ],
+)
+async def test_cloud_adapter_configures_user_token_client_endpoint(
+    token_service_endpoint: str,
+):
+    adapter = CloudAdapter(
+        connection_manager=cast(Connections, object()),
+        channel_service_client_factory_options={
+            "token_service_endpoint": token_service_endpoint
+        },
+    )
+    identity = ClaimsIdentity({"aud": "test-app-id"}, True)
+    context = TurnContext(
+        adapter,
+        Activity(
+            type="message",
+            conversation=ConversationAccount(id="conversation-id"),
+        ),
+        identity,
+    )
+
+    client = await adapter._channel_service_client_factory.create_user_token_client(
+        context,
+        identity,
+        use_anonymous=True,
+    )
+    assert isinstance(client, UserTokenClient)
+    try:
+        assert str(client.client._base_url) == f"{token_service_endpoint}/"
+    finally:
+        await client.close()

--- a/dev/integration/tests/adapter/test_fastapi_cloud_adapter.py
+++ b/dev/integration/tests/adapter/test_fastapi_cloud_adapter.py
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from typing import cast
+
+import pytest
+
+from microsoft_agents.activity import Activity, ConversationAccount
+from microsoft_agents.hosting.core import TurnContext
+from microsoft_agents.hosting.core.authorization import ClaimsIdentity, Connections
+from microsoft_agents.hosting.core.connector.client import UserTokenClient
+from microsoft_agents.hosting.fastapi import CloudAdapter
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "token_service_endpoint",
+    [
+        "https://europe.api.botframework.com",
+        "https://unitedstates.api.botframework.com",
+        "https://india.api.botframework.com",
+    ],
+)
+async def test_cloud_adapter_configures_user_token_client_endpoint(
+    token_service_endpoint: str,
+):
+    adapter = CloudAdapter(
+        connection_manager=cast(Connections, object()),
+        channel_service_client_factory_options={
+            "token_service_endpoint": token_service_endpoint
+        },
+    )
+    identity = ClaimsIdentity({"aud": "test-app-id"}, True)
+    context = TurnContext(
+        adapter,
+        Activity(
+            type="message",
+            conversation=ConversationAccount(id="conversation-id"),
+        ),
+        identity,
+    )
+
+    client = await adapter._channel_service_client_factory.create_user_token_client(
+        context,
+        identity,
+        use_anonymous=True,
+    )
+    assert isinstance(client, UserTokenClient)
+    try:
+        assert str(client.client._base_url) == f"{token_service_endpoint}/"
+    finally:
+        await client.close()

--- a/libraries/microsoft-agents-hosting-aiohttp/microsoft_agents/hosting/aiohttp/cloud_adapter.py
+++ b/libraries/microsoft-agents-hosting-aiohttp/microsoft_agents/hosting/aiohttp/cloud_adapter.py
@@ -24,16 +24,20 @@ class CloudAdapter(HttpAdapterBase, AgentHttpAdapter):
         *,
         connection_manager: Connections | None = None,
         channel_service_client_factory: ChannelServiceClientFactoryBase | None = None,
+        channel_service_client_factory_options: dict | None = None,
     ):
         """
         Initializes a new instance of the CloudAdapter class.
 
         :param connection_manager: Optional connection manager for OAuth.
-        :param channel_service_client_factory: The factory to use to create the channel service client.
+        :param channel_service_client_factory: Factory for creating channel service clients.
+        :param channel_service_client_factory_options: Optional dictionary of options to pass to the channel service client factory
+            This is only used if channel_service_client_factory is not provided and connection_manager is provided.
         """
         super().__init__(
             connection_manager=connection_manager,
             channel_service_client_factory=channel_service_client_factory,
+            channel_service_client_factory_options=channel_service_client_factory_options,
         )
 
     async def process(self, request: Request, agent: Agent) -> Optional[Response]:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/_http_adapter_base.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/_http_adapter_base.py
@@ -34,12 +34,14 @@ class HttpAdapterBase(ChannelServiceAdapter, ABC):
         *,
         connection_manager: Connections | None = None,
         channel_service_client_factory: ChannelServiceClientFactoryBase | None = None,
+        channel_service_client_factory_options: dict | None = None,
     ):
         """Initialize the HTTP adapter.
 
-        Args:
-            connection_manager: Optional connection manager for OAuth.
-            channel_service_client_factory: Factory for creating channel service clients.
+        :param connection_manager: Optional connection manager for OAuth.
+        :param channel_service_client_factory: Factory for creating channel service clients.
+        :param channel_service_client_factory_options: Optional dictionary of options to pass to the channel service client factory
+            This is only used if channel_service_client_factory is not provided and connection_manager is provided.
         """
 
         async def on_turn_error(context: TurnContext, error: Exception):
@@ -67,7 +69,10 @@ class HttpAdapterBase(ChannelServiceAdapter, ABC):
                 raise ValueError(
                     "HttpAdapterBase.__init__: Either channel_service_client_factory or connection_manager must be provided."
                 )
-            factory = RestChannelServiceClientFactory(connection_manager)
+            factory = RestChannelServiceClientFactory(
+                connection_manager,
+                **(channel_service_client_factory_options or {}),
+            )
 
         super().__init__(factory)
 

--- a/libraries/microsoft-agents-hosting-fastapi/microsoft_agents/hosting/fastapi/cloud_adapter.py
+++ b/libraries/microsoft-agents-hosting-fastapi/microsoft_agents/hosting/fastapi/cloud_adapter.py
@@ -25,16 +25,20 @@ class CloudAdapter(HttpAdapterBase, AgentHttpAdapter):
         *,
         connection_manager: Connections | None = None,
         channel_service_client_factory: ChannelServiceClientFactoryBase | None = None,
+        channel_service_client_factory_options: dict | None = None,
     ):
         """
         Initializes a new instance of the CloudAdapter class.
 
         :param connection_manager: Optional connection manager for OAuth.
-        :param channel_service_client_factory: The factory to use to create the channel service client.
+        :param channel_service_client_factory: Factory for creating channel service clients.
+        :param channel_service_client_factory_options: Optional dictionary of options to pass to the channel service client factory
+            This is only used if channel_service_client_factory is not provided and connection_manager is provided.
         """
         super().__init__(
             connection_manager=connection_manager,
             channel_service_client_factory=channel_service_client_factory,
+            channel_service_client_factory_options=channel_service_client_factory_options,
         )
 
     async def process(self, request: Request, agent: Agent) -> Optional[Response]:


### PR DESCRIPTION
This pull request adds support for configuring the `token_service_endpoint` for the user token client in both the `aiohttp` and `fastapi` `CloudAdapter` classes. This is achieved by allowing an options dictionary to be passed to the channel service client factory, and by testing that the correct endpoint is used. The main changes are grouped below.

### Feature: Configurable Token Service Endpoint

* Added a `channel_service_client_factory_options` parameter to the `CloudAdapter` constructors in both `aiohttp` and `fastapi` adapters, allowing users to specify options such as `token_service_endpoint`. [[1]](diffhunk://#diff-09b00d5a29fb3f0b5232c5b819d6526e04e9c7a45d271aadefb5a3ac9c33e5f5R27-R40) [[2]](diffhunk://#diff-635fc88c7f2dfe93c6653a81dd879c0e4bf676759d21a366cc2c7729e4a45657R28-R41)
* Updated the base HTTP adapter (`_http_adapter_base.py`) to accept and forward `channel_service_client_factory_options` when constructing the channel service client factory, ensuring these options are used in client creation. [[1]](diffhunk://#diff-0598d213e59e6f09f7a0a172f0a1584a752afe5831f844778ffe23f097193bcaR37-R44) [[2]](diffhunk://#diff-0598d213e59e6f09f7a0a172f0a1584a752afe5831f844778ffe23f097193bcaL70-R75)

### Testing

* Added integration tests for both the `aiohttp` and `fastapi` adapters to verify that the `UserTokenClient` is correctly configured with the provided `token_service_endpoint`. [[1]](diffhunk://#diff-dc34c15f73021018b05086b0589c6bf272ea0b6983758788c6457a508420e682R1-R52) [[2]](diffhunk://#diff-37096aae7a43c1672164a7ed289fd2af8d7c291d375b2a2ad1dd27e0696df025R1-R52)…Adapter creation