### PR TITLE
Add deprecated warning on `microsoft-agents-hosting-teams` package import

### DIFF
--- a/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/__init__.py
+++ b/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/__init__.py
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 import logging
 
 logging.warning(
-    "The `microsoft-agents-hosting-teams` package is obsolete. "
+    "The `microsoft-agents-hosting-teams` package is deprecated. "
     "Please start using the `microsoft-agents-hosting-msteams` package "
     "for better support and future updates. "
 )

--- a/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/__init__.py
+++ b/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/__init__.py
@@ -1,3 +1,16 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import logging
+
+logging.warning(
+    "The `microsoft-agents-hosting-teams` package is obsolete. "
+    "Please start using the `microsoft_agents.hosting.msteams` package "
+    "for better support and future updates. "
+)
+
 from .teams_activity_handler import TeamsActivityHandler
 from .teams_agent_extension import (
     TeamsAgentExtension,

--- a/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/__init__.py
+++ b/libraries/microsoft-agents-hosting-teams/microsoft_agents/hosting/teams/__init__.py
@@ -7,7 +7,7 @@ import logging
 
 logging.warning(
     "The `microsoft-agents-hosting-teams` package is obsolete. "
-    "Please start using the `microsoft_agents.hosting.msteams` package "
+    "Please start using the `microsoft-agents-hosting-msteams` package "
     "for better support and future updates. "
 )
 


### PR DESCRIPTION
This pull request adds a deprecation warning to the `microsoft-agents-hosting-teams` package, informing users that it is obsolete and recommending migration to the `microsoft-agents-hosting-msteams` package.

Deprecation notice:

* Added a logging warning at import time in `__init__.py` to notify users that `microsoft-agents-hosting-teams` is obsolete and to use `microsoft-agents-hosting-msteams` instead.