### PR TITLE
Supporting `WorkloadIdentity` auth type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Microsoft 365 Agents SDK for Python - Release Notes v1.4.0 (Unreleased)
 
+## Major Features & Enhancements
+- Added support for Workload Identity
+
 ## New Models & APIs
 - **Regionalized UserTokenClient Support**: Added optional argument to `CloudAdapter` to configure Token Service endpoint used by `RestChannelServiceClientFactory` when creating `UserTokenClient` instances. 
 

--- a/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
+++ b/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
@@ -291,8 +291,8 @@ class MsalAuth(AccessTokenProviderBase):
                 federated_token_file = self._msal_configuration.FEDERATED_TOKEN_FILE
 
                 def get_assertion() -> str:
-                    with open(federated_token_file, "rb") as f:
-                        return f.read().decode("utf-8")
+                    with open(federated_token_file, encoding="utf-8") as f:
+                        return f.read().strip()
 
                 client_credential = {"client_assertion": get_assertion}
             else:

--- a/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
+++ b/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
@@ -282,6 +282,19 @@ class MsalAuth(AccessTokenProviderBase):
                     return result["access_token"]
 
                 client_credential = {"client_assertion": get_assertion}
+            elif self._msal_configuration.AUTH_TYPE == AuthTypes.workload_identity:
+                if not self._msal_configuration.FEDERATED_TOKEN_FILE:
+                    raise ValueError(
+                        "FEDERATED_TOKEN_FILE must be set in configuration."
+                    )
+
+                federated_token_file = self._msal_configuration.FEDERATED_TOKEN_FILE
+
+                def get_assertion() -> str:
+                    with open(federated_token_file, "rb") as f:
+                        return f.read().decode("utf-8")
+
+                client_credential = {"client_assertion": get_assertion}
             else:
                 logger.error(
                     f"Unsupported authentication type: {self._msal_configuration.AUTH_TYPE}"

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -82,6 +82,8 @@ class AgentAuthConfiguration:
         enforced by JwtTokenValidator (per issue #626) whenever the verified
         token's issuer is a recognized Entra issuer with a GUID tenant,
         regardless of this flag.
+    ANONYMOUS_ALLOWED: Whether anonymous access is allowed (default False).
+    FEDERATED_TOKEN_FILE: The path to the federated token file (if using federated credentials authentication).
     """
 
     TENANT_ID: str | None

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -97,6 +97,7 @@ class AgentAuthConfiguration:
     IDPM_RESOURCE: str | None
     ANONYMOUS_ALLOWED: bool = False
     VALIDATE_ISSUER: bool = False
+    FEDERATED_TOKEN_FILE: str | None
 
     # Provider-specific settings that aren't first-class fields (e.g. the Entra
     # sidecar's SERVICE_NAME, SIDECAR_BASE_URL). Preserved here as a single dict
@@ -129,6 +130,7 @@ class AgentAuthConfiguration:
         anonymous_allowed: bool | None = None,
         issuers: list[str] | None = None,
         validate_issuer: bool | None = None,
+        federated_token_file: str | None = None,
         **kwargs: Any,
     ):
 
@@ -147,6 +149,9 @@ class AgentAuthConfiguration:
         self.CONNECTION_NAME = connection_name or kwargs.get("CONNECTIONNAME", None)
         self.FEDERATED_CLIENT_ID = federated_client_id or kwargs.get(
             "FEDERATEDCLIENTID", None
+        )
+        self.FEDERATED_TOKEN_FILE = federated_token_file or kwargs.get(
+            "FEDERATEDTOKENFILE", None
         )
         self.SCOPES = scopes or kwargs.get("SCOPES", None)
         # Azure regional token service. Falls back to the legacy "REGIONALAUTHORITY"

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -27,6 +27,7 @@ _RECOGNIZED_CONFIG_KEYS = frozenset(
         "CERTPFXFILE",
         "CONNECTIONNAME",
         "FEDERATEDCLIENTID",
+        "FEDERATEDTOKENFILE",
         "SCOPES",
         "AZUREREGION",
         "REGIONALAUTHORITY",

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/auth_types.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/auth_types.py
@@ -13,3 +13,4 @@ class AuthTypes(str, Enum):
     federated_credentials = "FederatedCredentials"
     identity_proxy_manager = "IdentityProxyManager"
     entra_auth_sidecar = "EntraAuthSideCar"
+    workload_identity = "WorkloadIdentity"

--- a/tests/authentication_msal/test_msal_auth.py
+++ b/tests/authentication_msal/test_msal_auth.py
@@ -263,7 +263,7 @@ class TestMsalAuthAzureRegion:
 class TestMsalAuthWorkloadIdentity:
     def test_create_client_application_reads_projected_token(self, mocker, tmp_path):
         token_file = tmp_path / "workload-token"
-        token_file.write_text("first-token", encoding="utf-8")
+        token_file.write_text("  first-token\r\n", encoding="utf-8")
         config = AgentAuthConfiguration(
             auth_type=AuthTypes.workload_identity,
             tenant_id="12345678-1234-1234-1234-123456789abc",
@@ -281,7 +281,7 @@ class TestMsalAuthWorkloadIdentity:
         ]
         assert client_assertion() == "first-token"
 
-        token_file.write_text("refreshed-token", encoding="utf-8")
+        token_file.write_text("\trefreshed-token\n", encoding="utf-8")
         assert client_assertion() == "refreshed-token"
 
     def test_create_client_application_requires_token_file(self):

--- a/tests/authentication_msal/test_msal_auth.py
+++ b/tests/authentication_msal/test_msal_auth.py
@@ -260,6 +260,43 @@ class TestMsalAuthAzureRegion:
         assert mock_cca.call_args.kwargs["azure_region"] is None
 
 
+class TestMsalAuthWorkloadIdentity:
+    def test_create_client_application_reads_projected_token(self, mocker, tmp_path):
+        token_file = tmp_path / "workload-token"
+        token_file.write_text("first-token", encoding="utf-8")
+        config = AgentAuthConfiguration(
+            auth_type=AuthTypes.workload_identity,
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            client_id="test-client-id",
+            federated_token_file=str(token_file),
+        )
+        mock_cca = mocker.patch(
+            "microsoft_agents.authentication.msal.msal_auth.ConfidentialClientApplication"
+        )
+
+        MsalAuth(config)._create_client_application()
+
+        client_assertion = mock_cca.call_args.kwargs["client_credential"][
+            "client_assertion"
+        ]
+        assert client_assertion() == "first-token"
+
+        token_file.write_text("refreshed-token", encoding="utf-8")
+        assert client_assertion() == "refreshed-token"
+
+    def test_create_client_application_requires_token_file(self):
+        config = AgentAuthConfiguration(
+            auth_type=AuthTypes.workload_identity,
+            tenant_id="12345678-1234-1234-1234-123456789abc",
+            client_id="test-client-id",
+        )
+
+        with pytest.raises(
+            ValueError, match="FEDERATED_TOKEN_FILE must be set in configuration"
+        ):
+            MsalAuth(config)._create_client_application()
+
+
 class TestMsalAuthIdentityProxyManager:
     """
     Test suite for the Identity Proxy Manager (IDPM) authentication type.

--- a/tests/hosting_core/test_auth_configuration.py
+++ b/tests/hosting_core/test_auth_configuration.py
@@ -102,6 +102,21 @@ class TestAuthorizationConfiguration:
         assert auth_config.SCOPES is None
         assert auth_config.AZURE_REGION is None
 
+    def test_workload_identity_token_file_from_kwargs(self):
+        auth_config = AgentAuthConfiguration(
+            AUTHTYPE="WorkloadIdentity",
+            CLIENTID="test-client-id",
+            TENANTID="test-tenant-id",
+            FEDERATEDTOKENFILE="/var/run/secrets/azure/tokens/azure-identity-token",
+        )
+
+        assert auth_config.AUTH_TYPE == AuthTypes.workload_identity
+        assert (
+            auth_config.FEDERATED_TOKEN_FILE
+            == "/var/run/secrets/azure/tokens/azure-identity-token"
+        )
+        assert "FEDERATEDTOKENFILE" not in auth_config.provider_settings
+
     def test_azure_region_from_parameter(self):
         auth_config = AgentAuthConfiguration(azure_region="westus")
         assert auth_config.AZURE_REGION == "westus"


### PR DESCRIPTION
This pull request adds support for Workload Identity authentication by introducing a new `workload_identity` authentication type and handling federated token files. The main changes involve updating the authentication configuration to accept a federated token file and modifying the MSAL authentication logic to use this file when the new authentication type is selected.

**Workload Identity Authentication Support**

* Added a new `workload_identity` value to the `AuthTypes` enum to represent the new authentication type.
* Updated `AgentAuthConfiguration` to include a `FEDERATED_TOKEN_FILE` field and accept it during initialization, allowing configuration of the federated token file path. [[1]](diffhunk://#diff-95d51f4d77954f159cb2ca3f096ff8f9862e4be3657f1e4f8b5370791895fd8fR100) [[2]](diffhunk://#diff-95d51f4d77954f159cb2ca3f096ff8f9862e4be3657f1e4f8b5370791895fd8fR133) [[3]](diffhunk://#diff-95d51f4d77954f159cb2ca3f096ff8f9862e4be3657f1e4f8b5370791895fd8fR153-R155)

**MSAL Authentication Logic**

* Modified the MSAL authentication flow to handle the `workload_identity` type: reads the federated token from the configured file and uses it as the client assertion for authentication. Raises a clear error if the federated token file is not set.