### PR TITLE
Removing sensitive info logging

### DIFF
--- a/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
+++ b/libraries/microsoft-agents-authentication-msal/microsoft_agents/authentication/msal/msal_auth.py
@@ -146,9 +146,7 @@ class MsalAuth(AccessTokenProviderBase):
                 )
 
                 if "access_token" not in token:
-                    logger.error(
-                        f"Failed to acquire token on behalf of user: {user_assertion}"
-                    )
+                    logger.error(f"Failed to acquire token on behalf of user.")
                     raise ValueError(
                         authentication_errors.FailedToAcquireToken.format(str(token))
                     )

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/_oauth/_oauth_flow.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/_oauth/_oauth_flow.py
@@ -126,7 +126,7 @@ class _OAuthFlow:
             magic_code=magic_code,
         )
         if token_response:
-            logger.info("User token obtained successfully: %s", token_response)
+            logger.info("User token obtained successfully")
             self._flow_state.expiration = (
                 datetime.now(timezone.utc).timestamp() + self._default_flow_duration
             )
@@ -315,10 +315,7 @@ class _OAuthFlow:
             self._flow_state.expiration = (
                 datetime.now(timezone.utc).timestamp() + self._default_flow_duration
             )
-            logger.debug(
-                "OAuth flow completed successfully, got TokenResponse: %s",
-                token_response,
-            )
+            logger.debug("OAuth flow completed successfully, got a token response.")
 
         return _FlowResponse(
             flow_state=self._flow_state.model_copy(),


### PR DESCRIPTION
This pull request makes improvements to logging messages in the authentication and OAuth flow code. The main changes focus on removing sensitive information from logs and making the log messages more generic to enhance security and privacy.

**Logging improvements:**

* [`msal_auth.py`](diffhunk://#diff-f3e673212ef75dc7b92e090cdb6682cce6dcf1a84ddcdb3bb31164041e21c39dL149-R149): Updated the error log in `acquire_token_on_behalf_of` to remove the user assertion from the message, reducing potential exposure of sensitive data.

* `_oauth_flow.py`:  
  - Changed the info log in `get_user_token` to avoid logging the entire token response, which may contain sensitive information.
  - Updated the debug log in `continue_flow` to no longer include the full `TokenResponse` object, further protecting sensitive details.