### PR TITLE
`AgentAuthConfiguration` validation based on auth type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+# Microsoft 365 Agents SDK for Python - Release Notes v1.5.0 (Unreleased)
+
+**Release Date:** Unreleased
+**Previous Version:** 1.4.0 (Released 2026-08-18)
+
+## Developer Experience
+
+- **Authentication Configuration Validation**: Added validation for certificate, federated credential, and workload identity authentication settings
+
+---
+
 # Microsoft 365 Agents SDK for Python - Release Notes v1.4.0
 
 **Release Date:** 2026-08-18

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -239,6 +239,13 @@ class AgentAuthConfiguration:
             raise ValueError(
                 "FEDERATED_CLIENT_ID is required for federated_credentials authentication."
             )
+        if (
+            self.AUTH_TYPE == AuthTypes.workload_identity
+            and not self.FEDERATED_TOKEN_FILE
+        ):
+            raise ValueError(
+                "FEDERATED_TOKEN_FILE is required for workload_identity authentication."
+            )
 
     @property
     def ISSUERS(self) -> list[str]:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -228,10 +228,6 @@ class AgentAuthConfiguration:
         """
         Validates the configuration. Raises ValueError if any required fields are missing or invalid.
         """
-        if self.AUTH_TYPE == AuthTypes.client_secret and not self.CLIENT_SECRET:
-            raise ValueError(
-                "CLIENT_SECRET is required for client_secret authentication."
-            )
         if self.AUTH_TYPE == AuthTypes.certificate and not self.CERT_PFX_FILE:
             raise ValueError(
                 "CERT_PFX_FILE is required for certificate authentication."

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -232,11 +232,10 @@ class AgentAuthConfiguration:
             raise ValueError(
                 "CERT_PFX_FILE is required for certificate authentication."
             )
-        if self.AUTH_TYPE == AuthTypes.identity_proxy_manager and not self.IDPM_RESOURCE:
-            raise ValueError(
-                "IDPM_RESOURCE is required for identity_proxy_manager authentication."
-            )
-        if self.AUTH_TYPE == AuthTypes.federated_credentials and not self.FEDERATED_CLIENT_ID:
+        if (
+            self.AUTH_TYPE == AuthTypes.federated_credentials
+            and not self.FEDERATED_CLIENT_ID
+        ):
             raise ValueError(
                 "FEDERATED_CLIENT_ID is required for federated_credentials authentication."
             )

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -222,6 +222,29 @@ class AgentAuthConfiguration:
         # JWT-patch: always at least include self for backward compat
         self._connections = {str(self.CONNECTION_NAME): self}
 
+        self._validate()
+
+    def _validate(self) -> None:
+        """
+        Validates the configuration. Raises ValueError if any required fields are missing or invalid.
+        """
+        if self.AUTH_TYPE == AuthTypes.client_secret and not self.CLIENT_SECRET:
+            raise ValueError(
+                "CLIENT_SECRET is required for client_secret authentication."
+            )
+        if self.AUTH_TYPE == AuthTypes.certificate and not self.CERT_PFX_FILE:
+            raise ValueError(
+                "CERT_PFX_FILE is required for certificate authentication."
+            )
+        if self.AUTH_TYPE == AuthTypes.identity_proxy_manager and not self.IDPM_RESOURCE:
+            raise ValueError(
+                "IDPM_RESOURCE is required for identity_proxy_manager authentication."
+            )
+        if self.AUTH_TYPE == AuthTypes.federated_credentials and not self.FEDERATED_CLIENT_ID:
+            raise ValueError(
+                "FEDERATED_CLIENT_ID is required for federated_credentials authentication."
+            )
+
     @property
     def ISSUERS(self) -> list[str]:
         """

--- a/tests/authentication_msal/test_msal_auth.py
+++ b/tests/authentication_msal/test_msal_auth.py
@@ -284,17 +284,16 @@ class TestMsalAuthWorkloadIdentity:
         token_file.write_text("\trefreshed-token\n", encoding="utf-8")
         assert client_assertion() == "refreshed-token"
 
-    def test_create_client_application_requires_token_file(self):
-        config = AgentAuthConfiguration(
-            auth_type=AuthTypes.workload_identity,
-            tenant_id="12345678-1234-1234-1234-123456789abc",
-            client_id="test-client-id",
-        )
-
+    def test_configuration_requires_token_file(self):
         with pytest.raises(
-            ValueError, match="FEDERATED_TOKEN_FILE must be set in configuration"
+            ValueError,
+            match="FEDERATED_TOKEN_FILE is required for workload_identity authentication",
         ):
-            MsalAuth(config)._create_client_application()
+            AgentAuthConfiguration(
+                auth_type=AuthTypes.workload_identity,
+                tenant_id="12345678-1234-1234-1234-123456789abc",
+                client_id="test-client-id",
+            )
 
 
 class TestMsalAuthIdentityProxyManager:

--- a/tests/hosting_core/test_auth_configuration.py
+++ b/tests/hosting_core/test_auth_configuration.py
@@ -1,4 +1,7 @@
 from os import environ
+
+import pytest
+
 from microsoft_agents.activity import load_configuration_from_env
 from microsoft_agents.hosting.core import AgentAuthConfiguration, AuthTypes
 
@@ -101,6 +104,39 @@ class TestAuthorizationConfiguration:
         assert auth_config.AUTHORITY is None
         assert auth_config.SCOPES is None
         assert auth_config.AZURE_REGION is None
+
+    @pytest.mark.parametrize(
+        ("auth_type", "expected_message"),
+        [
+            (
+                AuthTypes.certificate,
+                "CERT_PFX_FILE is required for certificate authentication.",
+            ),
+            (
+                AuthTypes.federated_credentials,
+                "FEDERATED_CLIENT_ID is required for "
+                "federated_credentials authentication.",
+            ),
+        ],
+    )
+    def test_auth_type_requires_credential_setting(self, auth_type, expected_message):
+        with pytest.raises(ValueError, match=expected_message):
+            AgentAuthConfiguration(auth_type=auth_type)
+
+    @pytest.mark.parametrize(
+        ("auth_type", "credential"),
+        [
+            (AuthTypes.certificate, {"cert_pfx_file": "test-cert.pfx"}),
+            (
+                AuthTypes.federated_credentials,
+                {"federated_client_id": "test-federated-client-id"},
+            ),
+        ],
+    )
+    def test_auth_type_accepts_required_credential_setting(self, auth_type, credential):
+        auth_config = AgentAuthConfiguration(auth_type=auth_type, **credential)
+
+        assert auth_config.AUTH_TYPE == auth_type
 
     def test_workload_identity_token_file_from_kwargs(self):
         auth_config = AgentAuthConfiguration(

--- a/tests/hosting_core/test_auth_configuration.py
+++ b/tests/hosting_core/test_auth_configuration.py
@@ -117,6 +117,11 @@ class TestAuthorizationConfiguration:
                 "FEDERATED_CLIENT_ID is required for "
                 "federated_credentials authentication.",
             ),
+            (
+                AuthTypes.workload_identity,
+                "FEDERATED_TOKEN_FILE is required for "
+                "workload_identity authentication.",
+            ),
         ],
     )
     def test_auth_type_requires_credential_setting(self, auth_type, expected_message):
@@ -130,6 +135,10 @@ class TestAuthorizationConfiguration:
             (
                 AuthTypes.federated_credentials,
                 {"federated_client_id": "test-federated-client-id"},
+            ),
+            (
+                AuthTypes.workload_identity,
+                {"federated_token_file": "test-token-file"},
             ),
         ],
     )


### PR DESCRIPTION
This pull request introduces validation for authentication configuration settings in the `AgentAuthConfiguration` class to improve reliability and developer experience. It ensures that required fields are present for certificate, federated credential, and workload identity authentication types. The update also adds comprehensive tests to verify that missing or valid credentials are handled correctly, and documents these changes in the changelog.

**Authentication configuration validation:**

* Added a `_validate` method to `AgentAuthConfiguration` that checks for required fields based on the authentication type and raises a `ValueError` if any are missing (certificate: `CERT_PFX_FILE`, federated credentials: `FEDERATED_CLIENT_ID`, workload identity: `FEDERATED_TOKEN_FILE`). (`libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py`)

**Testing improvements:**

* Added parameterized tests to ensure that missing required credential settings for each authentication type raise appropriate errors, and that providing the required settings allows successful configuration. (`tests/hosting_core/test_auth_configuration.py`)
* Updated MSAL authentication tests to expect a `ValueError` when the workload identity token file is missing, aligning with the new validation logic. (`tests/authentication_msal/test_msal_auth.py`)

**Documentation:**

* Added a new unreleased section to the changelog documenting the authentication configuration validation improvements. (`changelog.md`)