### PR TITLE
Broadening argument type for `load_configuration_from_env`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 ## Developer Experience
 
 - **Authentication Configuration Validation**: Added validation for certificate, federated credential, and workload identity authentication settings
+- **Configuration Loading**: Expanded `load_configuration_from_env` to accept any mapping type
 
 ---
 

--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_load_configuration.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_load_configuration.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 from typing import Any, Mapping
-from copy import copy
 
 from ._configure_logging import _configure_logging
 
@@ -11,7 +10,7 @@ def load_configuration_from_env(env_vars: Mapping[str, Any]) -> dict:
     """
     Parses environment variables and returns a dictionary with the relevant configuration.
     """
-    local_vars = copy(env_vars)
+    local_vars = dict(env_vars)
     result = {}
     for key, value in local_vars.items():
         levels = key.split("__")

--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_load_configuration.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/config/_load_configuration.py
@@ -1,18 +1,19 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import Any
+from typing import Any, Mapping
+from copy import copy
 
 from ._configure_logging import _configure_logging
 
 
-def load_configuration_from_env(env_vars: dict[str, Any]) -> dict:
+def load_configuration_from_env(env_vars: Mapping[str, Any]) -> dict:
     """
     Parses environment variables and returns a dictionary with the relevant configuration.
     """
-    vars = env_vars.copy()
+    local_vars = copy(env_vars)
     result = {}
-    for key, value in vars.items():
+    for key, value in local_vars.items():
         levels = key.split("__")
         current_level = result
         last_level = None

--- a/tests/activity/config/test_load_configuration.py
+++ b/tests/activity/config/test_load_configuration.py
@@ -1,3 +1,5 @@
+from types import MappingProxyType
+
 from microsoft_agents.activity import load_configuration_from_env
 
 from tests._common import create_env_var_dict
@@ -101,3 +103,21 @@ def test_load_configuration_from_env():
     input_dict = create_env_var_dict(ENV_RAW)
     config = load_configuration_from_env(input_dict)
     assert config == ENV_DICT
+
+
+def test_load_configuration_from_read_only_mapping():
+    input_mapping = MappingProxyType(create_env_var_dict(ENV_RAW))
+
+    config = load_configuration_from_env(input_mapping)
+
+    assert config == ENV_DICT
+
+
+def test_load_configuration_from_empty_mapping():
+    config = load_configuration_from_env({})
+
+    assert config == {
+        "AGENTAPPLICATION": {},
+        "CONNECTIONS": {},
+        "CONNECTIONSMAP": [],
+    }


### PR DESCRIPTION
This pull request refines the `load_configuration_from_env` function to improve type safety and avoid potential side effects when handling environment variables. The most important changes are:

Type safety and immutability improvements:

* Changed the type annotation for the `env_vars` parameter in `load_configuration_from_env` from `dict[str, Any]` to `Mapping[str, Any]`, allowing for more flexible and type-safe usage.
* Replaced the use of `env_vars.copy()` with `copy(env_vars)` to create a shallow copy, ensuring that the original mapping is not mutated and supporting non-dict mappings.
* Renamed the local variable from `vars` to `local_vars` for clarity and to avoid shadowing the built-in `vars()` function.