### PR TITLE
StreamInfo serialization/deserialization compatibility with .NET

### DIFF
--- a/libraries/microsoft-agents-activity/microsoft_agents/activity/entity/stream_info.py
+++ b/libraries/microsoft-agents-activity/microsoft_agents/activity/entity/stream_info.py
@@ -11,7 +11,7 @@ class StreamInfo(Entity):
     type: str = EntityTypes.STREAM_INFO.value
 
     stream_type: NonEmptyString = "streaming"
-    stream_sequence: int
+    stream_sequence: int | None = None
 
     stream_id: str = ""
     stream_result: str = ""

--- a/tests/activity/entity/test_validate_known_entities.py
+++ b/tests/activity/entity/test_validate_known_entities.py
@@ -84,6 +84,41 @@ def test_activity_matches_known_entity_types_case_insensitively(
     assert activity.entities[0].type == canonical_type
 
 
+@pytest.mark.parametrize(
+    "entity_data",
+    [
+        {"type": "streaminfo"},
+        {"type": "streaminfo", "streamSequence": None},
+    ],
+)
+def test_activity_deserializes_stream_info_without_sequence(entity_data):
+    activity = Activity.model_validate(
+        {
+            "type": "message",
+            "entities": [entity_data],
+        }
+    )
+
+    stream_info = activity.entities[0]
+
+    assert isinstance(stream_info, StreamInfo)
+    assert stream_info.stream_sequence is None
+
+
+def test_activity_omits_none_stream_sequence_when_serializing():
+    activity = Activity(type="message", entities=[StreamInfo()])
+
+    serialized = activity.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+    assert serialized["entities"][0] == {
+        "type": "streaminfo",
+        "streamType": "streaming",
+        "streamId": "",
+        "streamResult": "",
+        "feedbackLoopEnabled": False,
+    }
+
+
 def test_activity_preserves_unknown_entity_types():
     activity = Activity.model_validate(
         {


### PR DESCRIPTION
This pull request improves the handling of the optional `stream_sequence` field in the `StreamInfo` entity and adds corresponding tests to ensure correct serialization and deserialization behavior. The main changes focus on making `stream_sequence` optional and verifying that it is omitted from serialized output when not set.

**Entity model update:**

* Made the `stream_sequence` field in the `StreamInfo` entity optional by changing its type to `int | None` and setting its default value to `None`.

**Testing improvements:**

* Added tests to verify that the `StreamInfo` entity can be deserialized without a `streamSequence` field or with it explicitly set to `None`, and that the `stream_sequence` attribute is `None` in those cases.
* Added a test to ensure that when serializing an `Activity` containing a `StreamInfo` entity with `stream_sequence` set to `None`, the `streamSequence` field is omitted from the serialized output.