### PR TITLE
Add Storage V2 support across hosting providers

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/__init__.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/__init__.py
@@ -104,7 +104,22 @@ from .state.user_state import UserState
 
 # Storage
 from .storage.store_item import StoreItem
-from .storage import Storage
+from .storage import (
+    Storage,
+    StorageDeleteOptions,
+    StorageDeleteResult,
+    StorageDeleteResults,
+    StorageOperationStatus,
+    StorageProvider,
+    StorageReadResult,
+    StorageReadResults,
+    StorageV2,
+    StorageVersion,
+    StorageWriteMode,
+    StorageWriteOptions,
+    StorageWriteResult,
+    StorageWriteResults,
+)
 from .storage.memory_storage import MemoryStorage
 
 # Error Resources
@@ -185,6 +200,19 @@ __all__ = [
     "UserState",
     "StoreItem",
     "Storage",
+    "StorageV2",
+    "StorageProvider",
+    "StorageVersion",
+    "StorageOperationStatus",
+    "StorageWriteMode",
+    "StorageWriteOptions",
+    "StorageDeleteOptions",
+    "StorageReadResult",
+    "StorageReadResults",
+    "StorageWriteResult",
+    "StorageWriteResults",
+    "StorageDeleteResult",
+    "StorageDeleteResults",
     "MemoryStorage",
     "AgenticUserAuthorization",
     "Authorization",

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/_oauth/_flow_storage_client.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/_oauth/_flow_storage_client.py
@@ -1,7 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from ..storage import Storage
+from ..storage import Storage, StorageProvider
+from ..storage.storage_compatibility import (
+    as_storage_v2,
+    assert_storage_delete_succeeded,
+    assert_storage_write_succeeded,
+    get_storage_read_value,
+)
 from ._flow_state import _FlowState
 
 
@@ -31,8 +37,8 @@ class _FlowStorageClient:
         self,
         channel_id: str,
         user_id: str,
-        storage: Storage,
-        cache_class: type[Storage] | None = None,
+        storage: StorageProvider,
+        cache_class: type[StorageProvider] | None = None,
     ):
         """
         Args:
@@ -66,26 +72,40 @@ class _FlowStorageClient:
     async def read(self, auth_handler_id: str) -> _FlowState | None:
         """Reads the flow state for a specific authentication handler."""
         key: str = self.key(auth_handler_id)
-        data = await self._cache.read([key], target_cls=_FlowState)
-        if key not in data:
-            data = await self._storage.read([key], target_cls=_FlowState)
-            if key not in data:
+        cached = await as_storage_v2(self._cache).read([key], target_cls=_FlowState)
+        data = get_storage_read_value(cached, key)
+        if data is None:
+            results = await as_storage_v2(self._storage).read(
+                [key], target_cls=_FlowState
+            )
+            data = get_storage_read_value(results, key)
+            if data is None:
                 return None
-            await self._cache.write({key: data[key]})
-        return data.get(key)
+            cached_results = await as_storage_v2(self._cache).write({key: data})
+            assert_storage_write_succeeded(cached_results, [key])
+        return data
 
     async def write(self, value: _FlowState) -> None:
         """Saves the flow state for a specific authentication handler."""
         key: str = self.key(value.auth_handler_id)
-        cached_state = await self._cache.read([key], target_cls=_FlowState)
-        if not cached_state or cached_state.get(key, None) != value:
-            await self._cache.write({key: value})
-            await self._storage.write({key: value})
+        cached_results = await as_storage_v2(self._cache).read(
+            [key], target_cls=_FlowState
+        )
+        cached_state = get_storage_read_value(cached_results, key)
+        if cached_state != value:
+            cache_write = await as_storage_v2(self._cache).write({key: value})
+            assert_storage_write_succeeded(cache_write, [key])
+            storage_write = await as_storage_v2(self._storage).write({key: value})
+            assert_storage_write_succeeded(storage_write, [key])
 
     async def delete(self, auth_handler_id: str) -> None:
         """Deletes the flow state for a specific authentication handler."""
         key: str = self.key(auth_handler_id)
-        cached_state = await self._cache.read([key], target_cls=_FlowState)
-        if cached_state:
-            await self._cache.delete([key])
-        await self._storage.delete([key])
+        cached_state = await as_storage_v2(self._cache).read(
+            [key], target_cls=_FlowState
+        )
+        if get_storage_read_value(cached_state, key) is not None:
+            cache_delete = await as_storage_v2(self._cache).delete([key])
+            assert_storage_delete_succeeded(cache_delete, [key])
+        storage_delete = await as_storage_v2(self._storage).delete([key])
+        assert_storage_delete_succeeded(storage_delete, [key])

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/app_options.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/app_options.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional
 
 from microsoft_agents.hosting.core.app.oauth import AuthHandler
 from microsoft_agents.hosting.core.authorization import Connections
-from microsoft_agents.hosting.core.storage import Storage
+from microsoft_agents.hosting.core.storage import StorageProvider
 
 # from .auth import AuthOptions
 from .typing_indicator import TypingOptions
@@ -33,7 +33,7 @@ class ApplicationOptions:
     Optional. `AgentApplication` ID of the bot.
     """
 
-    storage: Optional[Storage] = None
+    storage: Optional[StorageProvider] = None
     """
     Optional. `Storage` provider to use for the application.
     """

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_authorization_handler.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/_authorization_handler.py
@@ -10,7 +10,7 @@ import logging
 from microsoft_agents.activity import TokenResponse
 
 from ....turn_context import TurnContext
-from ....storage import Storage
+from ....storage import StorageProvider
 from ....authorization import Connections
 from ..auth_handler import AuthHandler
 from .._sign_in_response import _SignInResponse
@@ -21,13 +21,13 @@ logger = logging.getLogger(__name__)
 class _AuthorizationHandler(ABC):
     """Base class for different authorization strategies."""
 
-    _storage: Storage
+    _storage: StorageProvider
     _connection_manager: Connections
     _handler: AuthHandler
 
     def __init__(
         self,
-        storage: Storage,
+        storage: StorageProvider,
         connection_manager: Connections,
         auth_handler: Optional[AuthHandler] = None,
         *,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/agentic_user_authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/agentic_user_authorization.py
@@ -13,7 +13,7 @@ from ....turn_context import TurnContext
 from ...._oauth import _FlowStateTag
 from .._sign_in_response import _SignInResponse
 from ._authorization_handler import _AuthorizationHandler
-from ....storage import Storage
+from ....storage import StorageProvider
 from ....authorization import Connections
 from ..auth_handler import AuthHandler
 from ..telemetry import spans
@@ -26,7 +26,7 @@ class AgenticUserAuthorization(_AuthorizationHandler):
 
     def __init__(
         self,
-        storage: Storage,
+        storage: StorageProvider,
         connection_manager: Connections,
         auth_handler: Optional[AuthHandler] = None,
         *,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/connector_user_authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/_handlers/connector_user_authorization.py
@@ -13,7 +13,7 @@ from microsoft_agents.hosting.core.errors import ErrorResources
 
 from ...._oauth._flow_state import _FlowStateTag
 from ....turn_context import TurnContext
-from ....storage import Storage
+from ....storage import StorageProvider
 from ....authorization import Connections
 from ..auth_handler import AuthHandler
 from ._authorization_handler import _AuthorizationHandler
@@ -30,7 +30,7 @@ class ConnectorUserAuthorization(_AuthorizationHandler):
 
     def __init__(
         self,
-        storage: Storage,
+        storage: StorageProvider,
         connection_manager: Connections,
         auth_handler: Optional[AuthHandler] = None,
         *,

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/oauth/authorization.py
@@ -17,7 +17,13 @@ from microsoft_agents.activity import (
 from microsoft_agents.activity.activity_types import ActivityTypes
 
 from ...turn_context import TurnContext
-from ...storage import Storage
+from ...storage import StorageProvider
+from ...storage.storage_compatibility import (
+    as_storage_v2,
+    assert_storage_delete_succeeded,
+    assert_storage_write_succeeded,
+    get_storage_read_value,
+)
 from ...authorization import Connections
 from ..._oauth import _FlowStateTag
 from ..state import TurnState
@@ -52,13 +58,13 @@ class _AuthInterceptResult:
 class Authorization:
     """Class responsible for managing authorization flows."""
 
-    _storage: Storage
+    _storage: StorageProvider
     _connection_manager: Connections
     _handlers: dict[str, _AuthorizationHandler]
 
     def __init__(
         self,
-        storage: Storage,
+        storage: StorageProvider,
         connection_manager: Connections,
         auth_handlers: Optional[dict[str, AuthHandler]] = None,
         auto_sign_in: bool = False,
@@ -174,7 +180,10 @@ class Authorization:
         :rtype: Optional[:class:`microsoft_agents.hosting.core.app.oauth._sign_in_state._SignInState`]
         """
         key = self._sign_in_state_key(context)
-        return (await self._storage.read([key], target_cls=_SignInState)).get(key)
+        results = await as_storage_v2(self._storage).read(
+            [key], target_cls=_SignInState
+        )
+        return get_storage_read_value(results, key)
 
     async def _save_sign_in_state(
         self, context: TurnContext, state: _SignInState
@@ -187,7 +196,8 @@ class Authorization:
         :type state: :class:`microsoft_agents.hosting.core.app.oauth._sign_in_state._SignInState`
         """
         key = self._sign_in_state_key(context)
-        await self._storage.write({key: state})
+        results = await as_storage_v2(self._storage).write({key: state})
+        assert_storage_write_succeeded(results, [key])
 
     async def _delete_sign_in_state(self, context: TurnContext) -> None:
         """Delete the sign-in state from storage for the given context.
@@ -196,7 +206,8 @@ class Authorization:
         :type context: :class:`microsoft_agents.hosting.core.turn_context.TurnContext`
         """
         key = self._sign_in_state_key(context)
-        await self._storage.delete([key])
+        results = await as_storage_v2(self._storage).delete([key])
+        assert_storage_delete_succeeded(results, [key])
 
     @staticmethod
     def _cache_key(context: TurnContext, handler_id: str) -> str:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive.py
@@ -9,7 +9,13 @@ from typing import Awaitable, Callable, Generic, TypeVar, TYPE_CHECKING
 from microsoft_agents.activity import Activity, ResourceResponse
 
 from microsoft_agents.hosting.core.app.state.turn_state import TurnState
-from microsoft_agents.hosting.core.storage import Storage
+from microsoft_agents.hosting.core.storage import StorageProvider
+from microsoft_agents.hosting.core.storage.storage_compatibility import (
+    as_storage_v2,
+    assert_storage_delete_succeeded,
+    assert_storage_write_succeeded,
+    get_storage_read_value,
+)
 
 from .conversation import Conversation
 from .create_conversation_options import CreateConversationOptions
@@ -76,7 +82,7 @@ class Proactive(Generic[StateT]):
         return f"{_STORAGE_KEY_PREFIX}{conversation_id}"
 
     @property
-    def _storage(self) -> Storage:
+    def _storage(self) -> StorageProvider:
         storage = self._options.storage or self._app.options.storage
         if not storage:
             raise RuntimeError(
@@ -126,7 +132,8 @@ class Proactive(Generic[StateT]):
             conversation.validate()
             key = self._storage_key(conversation.conversation_reference.conversation.id)
             logger.debug("Storing conversation with key: %s", key)
-            await self._storage.write({key: conversation})
+            results = await as_storage_v2(self._storage).write({key: conversation})
+            assert_storage_write_succeeded(results, [key])
 
     async def get_conversation(self, conversation_id: str) -> Conversation | None:
         """
@@ -141,8 +148,10 @@ class Proactive(Generic[StateT]):
         """
         with spans.ProactiveGetConversation(conversation_id) as span:
             key = self._storage_key(conversation_id)
-            results = await self._storage.read([key], target_cls=Conversation)
-            conversation = results.get(key)
+            results = await as_storage_v2(self._storage).read(
+                [key], target_cls=Conversation
+            )
+            conversation = get_storage_read_value(results, key)
             span.share(found=conversation is not None)
             return conversation
 
@@ -156,7 +165,8 @@ class Proactive(Generic[StateT]):
         with spans.ProactiveDeleteConversation(conversation_id):
             key = self._storage_key(conversation_id)
             logger.debug("Deleting conversation with key: %s", key)
-            await self._storage.delete([key])
+            results = await as_storage_v2(self._storage).delete([key])
+            assert_storage_delete_succeeded(results, [key])
 
     # ------------------------------------------------------------------
     # Send a single activity

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive_options.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/proactive/proactive_options.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from microsoft_agents.hosting.core.storage import Storage
+from microsoft_agents.hosting.core.storage import StorageProvider
 
 
 @dataclass
@@ -24,7 +24,7 @@ class ProactiveOptions:
     :type fail_on_unsigned_in_connections: bool
     """
 
-    storage: Storage | None = None
+    storage: StorageProvider | None = None
     """Storage used to persist Conversation objects."""
 
     fail_on_unsigned_in_connections: bool = True

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/state/conversation_state.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/state/conversation_state.py
@@ -8,7 +8,7 @@ import logging
 
 from typing import Type
 
-from microsoft_agents.hosting.core.storage import Storage, StoreItem
+from microsoft_agents.hosting.core.storage import StorageProvider, StoreItem
 
 from microsoft_agents.hosting.core.turn_context import TurnContext
 from microsoft_agents.hosting.core.state import AgentState
@@ -23,7 +23,7 @@ class ConversationState(AgentState):
 
     CONTEXT_SERVICE_KEY = "ConversationState"
 
-    def __init__(self, storage: Storage) -> None:
+    def __init__(self, storage: StorageProvider) -> None:
         """
         Initialize ConversationState with a key and optional properties.
 

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/state/turn_state.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/state/turn_state.py
@@ -9,7 +9,7 @@ import logging
 from typing import Any, Optional, Type, TypeVar, Callable
 import asyncio
 
-from microsoft_agents.hosting.core.storage import Storage
+from microsoft_agents.hosting.core.storage import StorageProvider
 
 from microsoft_agents.hosting.core.turn_context import TurnContext
 from microsoft_agents.hosting.core.app.state.conversation_state import ConversationState
@@ -52,7 +52,9 @@ class TurnState:
             self._scopes[TempState.SCOPE_NAME] = TempState()
 
     @classmethod
-    def with_storage(cls, storage: Storage, *agent_states: AgentState) -> "TurnState":
+    def with_storage(
+        cls, storage: StorageProvider, *agent_states: AgentState
+    ) -> "TurnState":
         """
         Creates TurnState with default ConversationState and UserState.
 
@@ -277,7 +279,7 @@ class TurnState:
         ]
         await asyncio.gather(*tasks)
 
-    async def load(self, context: TurnContext, storage: Storage) -> "TurnState":
+    async def load(self, context: TurnContext, storage: StorageProvider) -> "TurnState":
         """
         Loads a TurnState instance with the default states.
 

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/client/conversation_id_factory.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/client/conversation_id_factory.py
@@ -2,10 +2,14 @@
 # Licensed under the MIT License.
 
 from uuid import uuid4
-from functools import partial
-
 from microsoft_agents.activity import AgentsModel
-from microsoft_agents.hosting.core.storage import Storage, StoreItem
+from microsoft_agents.hosting.core.storage import StorageProvider, StoreItem
+from microsoft_agents.hosting.core.storage.storage_compatibility import (
+    as_storage_v2,
+    assert_storage_delete_succeeded,
+    assert_storage_write_succeeded,
+    get_storage_read_value,
+)
 
 from .agent_conversation_reference import AgentConversationReference
 from .conversation_id_factory_protocol import ConversationIdFactoryProtocol
@@ -14,17 +18,24 @@ from .conversation_id_factory_protocol import ConversationIdFactoryProtocol
 def _implement_store_item_for_agents_model_cls(model_instance: AgentsModel):
     instance_cls = type(model_instance)
     if not isinstance(model_instance, StoreItem):
-        instance_cls = type(model_instance)
+
+        def store_item_to_json(instance):
+            return instance.model_dump(mode="json", exclude_none=True)
+
+        @classmethod
+        def from_json_to_store_item(cls, data):
+            return cls.model_validate(data)
+
         setattr(
             instance_cls,
             "store_item_to_json",
-            partial(model_instance.model_dump, mode="json", exclude_none=True),
+            store_item_to_json,
         )
-        instance_cls.from_json_to_store_item = classmethod(instance_cls.model_validate)
+        instance_cls.from_json_to_store_item = from_json_to_store_item
 
 
 class ConversationIdFactory(ConversationIdFactoryProtocol):
-    def __init__(self, storage: Storage) -> None:
+    def __init__(self, storage: StorageProvider) -> None:
         if not storage:
             raise ValueError("ConversationIdFactory.__init__(): storage cannot be None")
         self._storage = storage
@@ -46,7 +57,8 @@ class ConversationIdFactory(ConversationIdFactoryProtocol):
         _implement_store_item_for_agents_model_cls(agent_conversation_reference)
 
         conversation_info = {agent_conversation_id: agent_conversation_reference}
-        await self._storage.write(conversation_info)
+        results = await as_storage_v2(self._storage).write(conversation_info)
+        assert_storage_write_succeeded(results, [agent_conversation_id])
 
         return agent_conversation_id
 
@@ -58,11 +70,14 @@ class ConversationIdFactory(ConversationIdFactoryProtocol):
                 "ConversationIdFactory.get_agent_conversation_reference(): agent_conversation_id cannot be None"
             )
 
-        storage_record = await self._storage.read(
+        storage_record = await as_storage_v2(self._storage).read(
             [agent_conversation_id], target_cls=AgentConversationReference
         )
-
-        return storage_record[agent_conversation_id]
+        result = get_storage_read_value(storage_record, agent_conversation_id)
+        if result is None:
+            raise KeyError(agent_conversation_id)
+        return result
 
     async def delete_conversation_reference(self, agent_conversation_id):
-        await self._storage.delete([agent_conversation_id])
+        results = await as_storage_v2(self._storage).delete([agent_conversation_id])
+        assert_storage_delete_succeeded(results, [agent_conversation_id])

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/state/agent_state.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/state/agent_state.py
@@ -8,7 +8,14 @@ from copy import deepcopy
 import logging
 from typing import Callable, Type
 
-from microsoft_agents.hosting.core.storage import Storage, StoreItem
+from microsoft_agents.hosting.core.storage import StorageProvider, StoreItem
+from microsoft_agents.hosting.core.storage.storage_compatibility import (
+    as_storage,
+    as_storage_v2,
+    assert_storage_delete_succeeded,
+    assert_storage_write_succeeded,
+    get_storage_read_value,
+)
 
 from .state_property_accessor import StatePropertyAccessor
 from ..turn_context import TurnContext
@@ -73,7 +80,7 @@ class AgentState:
         You can define additional scopes for your agent.
     """
 
-    def __init__(self, storage: Storage, context_service_key: str):
+    def __init__(self, storage: StorageProvider, context_service_key: str):
         """
         Initializes a new instance of the :class:`microsoft_agents.hosting.core.state.agent_state.AgentState` class.
 
@@ -90,9 +97,15 @@ class AgentState:
         :raises: It raises an argument null exception.
         """
         self.state_key = "state"
-        self._storage = storage
+        # Keep the legacy field for subclasses that access or replace it.
+        self._storage = as_storage(storage)
         self._context_service_key = context_service_key
         self._cached_state: CachedAgentState | None = None
+
+    @property
+    def _storage_v2(self):
+        """Get the current storage field through the V2 compatibility seam."""
+        return as_storage_v2(self._storage)
 
     def get_cached_state(
         self, turn_context: TurnContext | None = None
@@ -154,8 +167,10 @@ class AgentState:
         storage_key = self.get_storage_key(turn_context)
 
         if self._should_load(turn_context, force):
-            items = await self._storage.read([storage_key], target_cls=CachedAgentState)
-            val = items.get(storage_key, CachedAgentState())
+            items = await self._storage_v2.read(
+                [storage_key], target_cls=CachedAgentState
+            )
+            val = get_storage_read_value(items, storage_key) or CachedAgentState()
             self._cached_state = val
             turn_context.turn_state[self._context_service_key] = val
 
@@ -191,7 +206,8 @@ class AgentState:
         if force or (cached_state is not None and cached_state.is_changed):
             storage_key = self.get_storage_key(turn_context)
             changes: dict[str, StoreItem] = {storage_key: cached_state}
-            await self._storage.write(changes)
+            results = await self._storage_v2.write(changes)
+            assert_storage_write_succeeded(results, list(changes))
             cached_state.hash = cached_state.compute_hash()
 
     def clear(self, turn_context: TurnContext | None = None) -> None:
@@ -229,7 +245,8 @@ class AgentState:
         turn_context.turn_state.pop(self._context_service_key)
 
         storage_key = self.get_storage_key(turn_context)
-        await self._storage.delete({storage_key})
+        results = await self._storage_v2.delete([storage_key])
+        assert_storage_delete_succeeded(results, [storage_key])
 
     @abstractmethod
     def get_storage_key(

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/state/user_state.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/state/user_state.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from microsoft_agents.hosting.core.storage import Storage
+from microsoft_agents.hosting.core.storage import StorageProvider
 
 from ..turn_context import TurnContext
 from .agent_state import AgentState
@@ -16,7 +16,7 @@ class UserState(AgentState):
         "UserState: channel_id and/or conversation missing from context.activity."
     )
 
-    def __init__(self, storage: Storage, namespace=""):
+    def __init__(self, storage: StorageProvider, namespace=""):
         """
         Creates a new UserState instance.
         :param storage:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/__init__.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/__init__.py
@@ -2,7 +2,25 @@
 # Licensed under the MIT License.
 
 from .store_item import StoreItem
-from .storage import Storage, AsyncStorageBase
+from .storage import (
+    AsyncStorageBase,
+    Storage,
+    StorageDeleteOptions,
+    StorageDeleteResult,
+    StorageDeleteResults,
+    StorageOperationStatus,
+    StorageProvider,
+    StorageReadResult,
+    StorageReadResults,
+    StorageV2,
+    StorageVersion,
+    StorageVersionT,
+    StorageWriteMode,
+    StorageWriteOptions,
+    StorageWriteResult,
+    StorageWriteResults,
+    is_store_item,
+)
 from .memory_storage import MemoryStorage
 
 from .transcript import (
@@ -19,6 +37,21 @@ from .transcript import (
 __all__ = [
     "StoreItem",
     "Storage",
+    "StorageV2",
+    "StorageProvider",
+    "StorageVersion",
+    "StorageVersionT",
+    "StorageOperationStatus",
+    "StorageWriteMode",
+    "StorageWriteOptions",
+    "StorageDeleteOptions",
+    "StorageReadResult",
+    "StorageReadResults",
+    "StorageWriteResult",
+    "StorageWriteResults",
+    "StorageDeleteResult",
+    "StorageDeleteResults",
+    "is_store_item",
     "AsyncStorageBase",
     "MemoryStorage",
     "TranscriptInfo",

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/memory_storage.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/memory_storage.py
@@ -2,30 +2,91 @@
 # Licensed under the MIT License.
 
 from asyncio import Lock
-from typing import TypeVar
+from copy import deepcopy
+from typing import Generic, Literal, TypeVar, cast, overload
 
 from ._type_aliases import JSON
-from .storage import Storage
+from .storage import (
+    Storage,
+    StorageDeleteOptions,
+    StorageDeleteResult,
+    StorageDeleteResults,
+    StorageOperationStatus,
+    StorageReadResult,
+    StorageReadResults,
+    StorageV2,
+    StorageVersion,
+    StorageVersionT,
+    StorageWriteMode,
+    StorageWriteOptions,
+    StorageWriteResult,
+    StorageWriteResults,
+    is_store_item,
+)
 from .store_item import StoreItem
+from .storage_compatibility import (
+    validate_expected_version,
+    validate_storage_v2_changes,
+    validate_storage_v2_keys,
+    validate_write_mode,
+)
+from .telemetry import spans
 
 StoreItemT = TypeVar("StoreItemT", bound=StoreItem)
 
 
-class MemoryStorage(Storage):
+class MemoryStorage(Storage, StorageV2, Generic[StorageVersionT]):
     """In-memory storage implementation for testing and development purposes."""
 
-    def __init__(self, state: dict[str, JSON] | None = None):
+    def __init__(
+        self,
+        state: dict[str, JSON] | None = None,
+        *,
+        storage_version: StorageVersionT = StorageVersion.V1,
+    ):
         """Initializes the MemoryStorage with an optional initial state.
 
         :param state: An optional dictionary representing the initial state of the storage.
         :raises ValueError: If state is not a dictionary or None.
         """
+        if storage_version not in (StorageVersion.V1, StorageVersion.V2):
+            raise ValueError(f'Storage version "{storage_version}" is not supported.')
+        self.storage_version = StorageVersion(storage_version)
         self._memory: dict[str, JSON] = state or {}
+        self._versions: dict[str, str] = {}
+        self._next_version = 1
         self._lock = Lock()
+
+    @overload
+    async def read(
+        self: "MemoryStorage[Literal[StorageVersion.V1]]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> dict[str, StoreItemT]: ...
+
+    @overload
+    async def read(
+        self: "MemoryStorage[Literal[StorageVersion.V2]]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> StorageReadResults[StoreItemT]: ...
+
+    @overload
+    async def read(
+        self: "MemoryStorage[StorageVersion]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> dict[str, StoreItemT] | StorageReadResults[StoreItemT]: ...
 
     async def read(
         self, keys: list[str], *, target_cls: type[StoreItemT], **kwargs
-    ) -> dict[str, StoreItemT]:
+    ) -> dict[str, StoreItemT] | StorageReadResults[StoreItemT]:
         """Reads items from the in-memory storage.
 
         :param keys: A list of keys to read from the storage.
@@ -34,6 +95,87 @@ class MemoryStorage(Storage):
         :raises ValueError: If keys are empty.
         """
 
+        with spans.StorageRead(len(keys) if isinstance(keys, list) else 0):
+            if self.storage_version == StorageVersion.V2:
+                return await self._read_v2(keys, target_cls=target_cls)
+            return await self._read_v1(keys, target_cls=target_cls)
+
+    @overload
+    async def write(
+        self: "MemoryStorage[Literal[StorageVersion.V1]]",
+        changes: dict[str, StoreItem],
+        options: None = None,
+    ) -> None: ...
+
+    @overload
+    async def write(
+        self: "MemoryStorage[Literal[StorageVersion.V2]]",
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> StorageWriteResults: ...
+
+    @overload
+    async def write(
+        self: "MemoryStorage[StorageVersion]",
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> None | StorageWriteResults: ...
+
+    async def write(
+        self,
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> None | StorageWriteResults:
+        """Writes items to the in-memory storage.
+
+        :param changes: A dictionary mapping keys to StoreItem instances to be written to the storage.
+        :raises ValueError: If changes is None or any key is empty.
+        """
+        with spans.StorageWrite(len(changes) if isinstance(changes, dict) else 0):
+            if self.storage_version == StorageVersion.V2:
+                return await self._write_v2(changes, options)
+            return await self._write_v1(changes)
+
+    @overload
+    async def delete(
+        self: "MemoryStorage[Literal[StorageVersion.V1]]",
+        keys: list[str],
+        options: None = None,
+    ) -> None: ...
+
+    @overload
+    async def delete(
+        self: "MemoryStorage[Literal[StorageVersion.V2]]",
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> StorageDeleteResults: ...
+
+    @overload
+    async def delete(
+        self: "MemoryStorage[StorageVersion]",
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> None | StorageDeleteResults: ...
+
+    async def delete(
+        self,
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> None | StorageDeleteResults:
+        """Deletes items from the in-memory storage.
+
+        :param keys: A list of keys to delete from the storage.
+        :raises ValueError: If keys is empty or any key is empty.
+        """
+
+        with spans.StorageDelete(len(keys) if isinstance(keys, list) else 0):
+            if self.storage_version == StorageVersion.V2:
+                return await self._delete_v2(keys, options)
+            return await self._delete_v1(keys)
+
+    async def _read_v1(
+        self, keys: list[str], *, target_cls: type[StoreItemT]
+    ) -> dict[str, StoreItemT]:
         if not keys:
             raise ValueError("Storage.read(): Keys are required when reading.")
 
@@ -43,16 +185,13 @@ class MemoryStorage(Storage):
                 if key == "":
                     raise ValueError("MemoryStorage.read(): key cannot be empty")
                 if key in self._memory:
-                    result[key] = target_cls.from_json_to_store_item(self._memory[key])
+                    result[key] = cast(
+                        StoreItemT,
+                        target_cls.from_json_to_store_item(self._memory[key]),
+                    )
+        return result
 
-            return result
-
-    async def write(self, changes: dict[str, StoreItem]):
-        """Writes items to the in-memory storage.
-
-        :param changes: A dictionary mapping keys to StoreItem instances to be written to the storage.
-        :raises ValueError: If changes is None or any key is empty.
-        """
+    async def _write_v1(self, changes: dict[str, StoreItem]) -> None:
         if not changes:
             raise ValueError("MemoryStorage.write(): changes cannot be None")
 
@@ -62,13 +201,7 @@ class MemoryStorage(Storage):
                     raise ValueError("MemoryStorage.write(): key cannot be empty")
                 self._memory[key] = changes[key].store_item_to_json()
 
-    async def delete(self, keys: list[str]):
-        """Deletes items from the in-memory storage.
-
-        :param keys: A list of keys to delete from the storage.
-        :raises ValueError: If keys is empty or any key is empty.
-        """
-
+    async def _delete_v1(self, keys: list[str]) -> None:
         if not keys:
             raise ValueError("Storage.delete(): Keys are required when deleting.")
 
@@ -76,5 +209,126 @@ class MemoryStorage(Storage):
             for key in keys:
                 if key == "":
                     raise ValueError("MemoryStorage.delete(): key cannot be empty")
-                if key in self._memory:
-                    del self._memory[key]
+                self._memory.pop(key, None)
+
+    async def _read_v2(
+        self, keys: list[str], *, target_cls: type[StoreItemT]
+    ) -> StorageReadResults[StoreItemT]:
+        validate_storage_v2_keys(keys)
+        async with self._lock:
+            results: StorageReadResults[StoreItemT] = {}
+            for key in keys:
+                if key not in self._memory:
+                    results[key] = cast(
+                        StorageReadResult[StoreItemT],
+                        StorageReadResult(
+                            key=key, status=StorageOperationStatus.NOT_FOUND
+                        ),
+                    )
+                    continue
+                results[key] = cast(
+                    StorageReadResult[StoreItemT],
+                    StorageReadResult(
+                        key=key,
+                        status=StorageOperationStatus.SUCCEEDED,
+                        value=cast(
+                            StoreItemT,
+                            target_cls.from_json_to_store_item(
+                                deepcopy(self._memory[key])
+                            ),
+                        ),
+                        version=self._versions.get(key),
+                    ),
+                )
+            return results
+
+    async def _write_v2(
+        self,
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None,
+    ) -> StorageWriteResults:
+        validate_storage_v2_changes(changes)
+        if not changes:
+            return {}
+        options = options or StorageWriteOptions()
+        validate_write_mode(options.mode)
+        validate_expected_version(options.expected_version)
+        if any(not is_store_item(value) for value in changes.values()):
+            raise ValueError("Storage V2 values must implement store_item_to_json().")
+
+        async with self._lock:
+            results: StorageWriteResults = {}
+            for key, value in changes.items():
+                exists = key in self._memory
+                current_version = self._versions.get(key)
+                if options.mode == StorageWriteMode.CREATE_ONLY and exists:
+                    results[key] = StorageWriteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONFLICT,
+                        version=current_version,
+                    )
+                elif options.mode == StorageWriteMode.REPLACE and not exists:
+                    results[key] = StorageWriteResult(
+                        key=key, status=StorageOperationStatus.NOT_FOUND
+                    )
+                elif (
+                    options.expected_version is not None
+                    and options.expected_version != current_version
+                ):
+                    results[key] = StorageWriteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONDITION_NOT_MET,
+                        version=current_version,
+                    )
+                else:
+                    version = self._new_version()
+                    self._memory[key] = deepcopy(value.store_item_to_json())
+                    self._versions[key] = version
+                    results[key] = StorageWriteResult(
+                        key=key,
+                        status=StorageOperationStatus.SUCCEEDED,
+                        version=version,
+                    )
+            return results
+
+    async def _delete_v2(
+        self,
+        keys: list[str],
+        options: StorageDeleteOptions | None,
+    ) -> StorageDeleteResults:
+        validate_storage_v2_keys(keys)
+        options = options or StorageDeleteOptions()
+        validate_expected_version(options.expected_version)
+
+        async with self._lock:
+            results: StorageDeleteResults = {}
+            for key in keys:
+                if key not in self._memory:
+                    results[key] = StorageDeleteResult(
+                        key=key, status=StorageOperationStatus.NOT_FOUND
+                    )
+                    continue
+                current_version = self._versions.get(key)
+                if (
+                    options.expected_version is not None
+                    and options.expected_version != current_version
+                ):
+                    results[key] = StorageDeleteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONDITION_NOT_MET,
+                        version=current_version,
+                    )
+                    continue
+                self._memory.pop(key)
+                self._versions.pop(key, None)
+                results[key] = StorageDeleteResult(
+                    key=key,
+                    status=StorageOperationStatus.SUCCEEDED,
+                    version=current_version,
+                )
+            return results
+
+    def _new_version(self) -> str:
+        version = str(self._next_version)
+        self._next_version += 1
+        return version

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/memory_storage.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/memory_storage.py
@@ -134,6 +134,8 @@ class MemoryStorage(Storage, StorageV2, Generic[StorageVersionT]):
         with spans.StorageWrite(len(changes) if isinstance(changes, dict) else 0):
             if self.storage_version == StorageVersion.V2:
                 return await self._write_v2(changes, options)
+            if options is not None:
+                raise ValueError("Storage write options require Storage V2.")
             return await self._write_v1(changes)
 
     @overload
@@ -171,6 +173,8 @@ class MemoryStorage(Storage, StorageV2, Generic[StorageVersionT]):
         with spans.StorageDelete(len(keys) if isinstance(keys, list) else 0):
             if self.storage_version == StorageVersion.V2:
                 return await self._delete_v2(keys, options)
+            if options is not None:
+                raise ValueError("Storage delete options require Storage V2.")
             return await self._delete_v1(keys)
 
     async def _read_v1(
@@ -193,7 +197,7 @@ class MemoryStorage(Storage, StorageV2, Generic[StorageVersionT]):
 
     async def _write_v1(self, changes: dict[str, StoreItem]) -> None:
         if not changes:
-            raise ValueError("MemoryStorage.write(): changes cannot be None")
+            raise ValueError("MemoryStorage.write(): changes cannot be empty")
 
         async with self._lock:
             for key in changes:

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/storage.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/storage.py
@@ -1,14 +1,103 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import TypeVar
+from dataclasses import dataclass
+from enum import Enum, IntEnum
+from typing import Generic, Literal, TypeAlias
 from abc import ABC, abstractmethod
 from asyncio import gather
+from typing_extensions import TypeVar
 
 from .store_item import StoreItem
 from .telemetry import spans
 
 StoreItemT = TypeVar("StoreItemT", bound=StoreItem)
+
+
+class StorageOperationStatus(str, Enum):
+    """Outcome of one version 2 storage operation."""
+
+    SUCCEEDED = "succeeded"
+    NOT_FOUND = "notFound"
+    CONFLICT = "conflict"
+    CONDITION_NOT_MET = "conditionNotMet"
+
+
+class StorageWriteMode(str, Enum):
+    """Write mode for a version 2 storage operation."""
+
+    UPSERT = "upsert"
+    CREATE_ONLY = "createOnly"
+    REPLACE = "replace"
+
+
+class StorageVersion(IntEnum):
+    """Supported storage contract versions."""
+
+    V1 = 1
+    V2 = 2
+
+
+StorageVersionT = TypeVar(
+    "StorageVersionT",
+    Literal[StorageVersion.V1],
+    Literal[StorageVersion.V2],
+    StorageVersion,
+    default=Literal[StorageVersion.V1],
+)
+
+
+def is_store_item(value: object) -> bool:
+    """Return whether a value can be serialized by a storage provider."""
+    return callable(getattr(value, "store_item_to_json", None))
+
+
+@dataclass(frozen=True, slots=True)
+class StorageWriteOptions:
+    """Options applied to every item in a version 2 write operation."""
+
+    mode: StorageWriteMode = StorageWriteMode.UPSERT
+    expected_version: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StorageDeleteOptions:
+    """Options applied to every item in a version 2 delete operation."""
+
+    expected_version: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StorageReadResult(Generic[StoreItemT]):
+    """Result for one version 2 read operation."""
+
+    key: str
+    status: StorageOperationStatus
+    value: StoreItemT | None = None
+    version: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StorageWriteResult:
+    """Result for one version 2 write operation."""
+
+    key: str
+    status: StorageOperationStatus
+    version: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StorageDeleteResult:
+    """Result for one version 2 delete operation."""
+
+    key: str
+    status: StorageOperationStatus
+    version: str | None = None
+
+
+StorageReadResults: TypeAlias = dict[str, StorageReadResult[StoreItemT]]
+StorageWriteResults: TypeAlias = dict[str, StorageWriteResult]
+StorageDeleteResults: TypeAlias = dict[str, StorageDeleteResult]
 
 
 class Storage(ABC):
@@ -43,6 +132,45 @@ class Storage(ABC):
         keys: A list of keys to delete.
         """
         pass
+
+
+class StorageV2(ABC):
+    """Version 2 storage interface.
+
+    Each operation returns a result for every requested key. Values remain
+    :class:`StoreItem` instances because the Python SDK requires an explicit
+    deserialization type for reads.
+    """
+
+    storage_version = StorageVersion.V2
+
+    @abstractmethod
+    async def read(
+        self, keys: list[str], *, target_cls: type[StoreItemT], **kwargs
+    ) -> StorageReadResults[StoreItemT]:
+        """Reads items and returns one result per requested key."""
+        pass
+
+    @abstractmethod
+    async def write(
+        self,
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> StorageWriteResults:
+        """Writes items and returns one result per requested key."""
+        pass
+
+    @abstractmethod
+    async def delete(
+        self,
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> StorageDeleteResults:
+        """Deletes items and returns one result per requested key."""
+        pass
+
+
+StorageProvider: TypeAlias = Storage | StorageV2
 
 
 class AsyncStorageBase(Storage):

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/storage_compatibility.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/storage/storage_compatibility.py
@@ -1,0 +1,222 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+"""Compatibility helpers for Storage V1 and Storage V2."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .storage import (
+    Storage,
+    StorageDeleteOptions,
+    StorageDeleteResults,
+    StorageDeleteResult,
+    StorageOperationStatus,
+    StorageProvider,
+    StoreItemT,
+    StorageReadResult,
+    StorageReadResults,
+    StorageV2,
+    StorageVersion,
+    StorageWriteMode,
+    StorageWriteOptions,
+    StorageWriteResults,
+    StorageWriteResult,
+)
+from .store_item import StoreItem
+
+
+def is_storage_v2(storage: StorageProvider) -> bool:
+    """Return ``True`` only for a provider that implements the V2 interface."""
+    return isinstance(storage, StorageV2) and (
+        storage.storage_version == StorageVersion.V2
+    )
+
+
+def as_storage_v2(storage: StorageProvider) -> StorageV2:
+    """Convert a supported provider to the V2 interface."""
+    if isinstance(storage, _StorageV2ToStorageAdapter):
+        return storage.source
+    if is_storage_v2(storage):
+        return storage
+    return _StorageToStorageV2Adapter(storage)
+
+
+def as_storage(storage: StorageProvider) -> Storage:
+    """Convert a supported provider to the legacy V1 interface."""
+    if is_storage_v2(storage):
+        return _StorageV2ToStorageAdapter(storage)
+    return storage
+
+
+def get_storage_read_value(
+    results: StorageReadResults[StoreItemT] | None, key: str
+) -> StoreItemT | None:
+    """Return a successful V2 value, map not-found to ``None``, or raise."""
+    result = results.get(key) if results is not None else None
+    if result is not None and result.status == StorageOperationStatus.NOT_FOUND:
+        return None
+    if result is not None and result.status == StorageOperationStatus.SUCCEEDED:
+        return result.value
+    _raise_result_error("read", key, result.status if result else None)
+
+
+def assert_storage_write_succeeded(
+    results: StorageWriteResults | None, keys: list[str]
+) -> None:
+    """Raise unless every V2 write result succeeded."""
+    _assert_results("write", results, keys, {StorageOperationStatus.SUCCEEDED})
+
+
+def assert_storage_delete_succeeded(
+    results: StorageDeleteResults | None, keys: list[str]
+) -> None:
+    """Raise unless every V2 delete kept V1 idempotent semantics."""
+    _assert_results(
+        "delete",
+        results,
+        keys,
+        {StorageOperationStatus.SUCCEEDED, StorageOperationStatus.NOT_FOUND},
+    )
+
+
+def validate_storage_v2_keys(keys: list[str]) -> None:
+    """Validate V2 key input."""
+    if not isinstance(keys, list):
+        raise ValueError("Storage V2 keys must be a list.")
+    if any(not isinstance(key, str) or not key.strip() for key in keys):
+        raise ValueError("Storage V2 keys must be non-empty strings.")
+
+
+def validate_storage_v2_changes(changes: Mapping[str, object]) -> None:
+    """Validate V2 change keys."""
+    if not isinstance(changes, dict):
+        raise ValueError("Storage V2 changes must be a dictionary.")
+    if any(not isinstance(key, str) or not key.strip() for key in changes):
+        raise ValueError("Storage V2 keys must be non-empty strings.")
+
+
+def validate_expected_version(expected_version: str | None) -> None:
+    """Validate an optional V2 version token."""
+    if expected_version == "":
+        raise ValueError("Storage V2 expected_version cannot be empty.")
+
+
+def validate_write_mode(mode: StorageWriteMode) -> None:
+    """Validate a V2 write mode."""
+    if not isinstance(mode, StorageWriteMode):
+        raise ValueError(f'Storage V2 write mode "{mode}" is not supported.')
+
+
+class _StorageV2ToStorageAdapter(Storage):
+    """Adapt V2 storage for V1 consumers."""
+
+    def __init__(self, storage: StorageV2):
+        self._storage = storage
+
+    @property
+    def source(self) -> StorageV2:
+        """Return the unwrapped V2 provider."""
+        return self._storage
+
+    async def read(self, keys, *, target_cls, **kwargs):
+        results = await self._storage.read(keys, target_cls=target_cls, **kwargs)
+        values: dict[str, StoreItem] = {}
+        for key in keys:
+            value = get_storage_read_value(results, key)
+            if value is not None:
+                values[key] = value
+        return values
+
+    async def write(self, changes: dict[str, StoreItem]) -> None:
+        results = await self._storage.write(changes)
+        assert_storage_write_succeeded(results, list(changes))
+
+    async def delete(self, keys: list[str]) -> None:
+        results = await self._storage.delete(keys)
+        assert_storage_delete_succeeded(results, keys)
+
+
+class _StorageToStorageV2Adapter(StorageV2):
+    """Adapt a legacy provider where V2 behavior is safely available."""
+
+    storage_version = StorageVersion.V2
+
+    def __init__(self, storage: Storage):
+        self._storage = storage
+
+    async def read(self, keys, *, target_cls, **kwargs):
+        validate_storage_v2_keys(keys)
+        if not keys:
+            return {}
+        items = await self._storage.read(keys, target_cls=target_cls, **kwargs)
+        return {
+            key: StorageReadResult(
+                key=key,
+                status=(
+                    StorageOperationStatus.SUCCEEDED
+                    if key in items
+                    else StorageOperationStatus.NOT_FOUND
+                ),
+                value=items.get(key),
+            )
+            for key in keys
+        }
+
+    async def write(self, changes, options=None):
+        validate_storage_v2_changes(changes)
+        if not changes:
+            return {}
+        options = options or StorageWriteOptions()
+        validate_write_mode(options.mode)
+        validate_expected_version(options.expected_version)
+        if options.mode != StorageWriteMode.UPSERT:
+            raise NotImplementedError(
+                'Legacy storage does not support the V2 storage option "mode".'
+            )
+        if options.expected_version is not None:
+            raise NotImplementedError(
+                "Legacy storage does not support the V2 storage option "
+                '"expected_version".'
+            )
+        await self._storage.write(changes)
+        return {
+            key: StorageWriteResult(key=key, status=StorageOperationStatus.SUCCEEDED)
+            for key in changes
+        }
+
+    async def delete(self, keys, options=None):
+        validate_storage_v2_keys(keys)
+        if not keys:
+            return {}
+        options = options or StorageDeleteOptions()
+        validate_expected_version(options.expected_version)
+        if options.expected_version is not None:
+            raise NotImplementedError(
+                "Legacy storage does not support the V2 storage option "
+                '"expected_version".'
+            )
+        await self._storage.delete(keys)
+        return {
+            key: StorageDeleteResult(key=key, status=StorageOperationStatus.SUCCEEDED)
+            for key in keys
+        }
+
+
+def _assert_results(operation, results, keys, accepted_statuses) -> None:
+    for key in keys:
+        result = results.get(key) if results is not None else None
+        if result is None or result.status not in accepted_statuses:
+            _raise_result_error(
+                operation, key, result.status if result is not None else None
+            )
+
+
+def _raise_result_error(
+    operation: str, key: str, status: StorageOperationStatus | None
+):
+    value = status.value if status is not None else "missing"
+    raise RuntimeError(
+        f'Storage V2 {operation} failed for key "{key}" with status "{value}".'
+    )

--- a/libraries/microsoft-agents-hosting-core/readme.md
+++ b/libraries/microsoft-agents-hosting-core/readme.md
@@ -237,7 +237,7 @@ async def on_error(context: TurnContext, error: Exception):
 
 ## Key Classes Reference
 
-## Storage V2
+### Storage V2
 
 Storage providers use V1 by default. Select V2 when your application needs a
 result for each key and optimistic concurrency:

--- a/libraries/microsoft-agents-hosting-core/readme.md
+++ b/libraries/microsoft-agents-hosting-core/readme.md
@@ -237,6 +237,33 @@ async def on_error(context: TurnContext, error: Exception):
 
 ## Key Classes Reference
 
+## Storage V2
+
+Storage providers use V1 by default. Select V2 when your application needs a
+result for each key and optimistic concurrency:
+
+```python
+from microsoft_agents.hosting.core.storage import (
+    MemoryStorage,
+    StorageVersion,
+    StorageWriteOptions,
+    StorageWriteMode,
+)
+
+storage = MemoryStorage(storage_version=StorageVersion.V2)
+results = await storage.write(
+    {"profile": profile},
+    StorageWriteOptions(mode=StorageWriteMode.CREATE_ONLY),
+)
+
+if results["profile"].status.value == "succeeded":
+    version = results["profile"].version
+```
+
+V2 operations return `succeeded`, `notFound`, `conflict`, or
+`conditionNotMet` for each requested key. The result `version` is a storage
+concurrency token. It is separate from model data.
+
 ### Core Classes
 - **`AgentApplication`** - Main application class with fluent API
 - **`ActivityHandler`** - Base class for inheritance-based agents

--- a/libraries/microsoft-agents-hosting-core/setup.py
+++ b/libraries/microsoft-agents-hosting-core/setup.py
@@ -20,5 +20,6 @@ setup(
         "opentelemetry-sdk>=1.27.0",
         "aiohttp>=3.11.11",
         "yarl>=1.17.0,<2.0",
+        "typing-extensions>=4.12.0",
     ],
 )

--- a/libraries/microsoft-agents-storage-blob/microsoft_agents/storage/blob/blob_storage.py
+++ b/libraries/microsoft-agents-storage-blob/microsoft_agents/storage/blob/blob_storage.py
@@ -1,19 +1,43 @@
 import json
-from typing import TypeVar
+from typing import Generic, Literal, TypeVar, cast, overload
 from io import BytesIO
 
+from azure.core import MatchConditions
 from azure.storage.blob.aio import (
     ContainerClient,
     BlobServiceClient,
 )
 
-from microsoft_agents.hosting.core.storage import StoreItem
+from microsoft_agents.hosting.core.storage import (
+    StoreItem,
+    StorageDeleteOptions,
+    StorageDeleteResult,
+    StorageDeleteResults,
+    StorageOperationStatus,
+    StorageReadResult,
+    StorageReadResults,
+    StorageV2,
+    StorageVersion,
+    StorageVersionT,
+    StorageWriteMode,
+    StorageWriteOptions,
+    StorageWriteResult,
+    StorageWriteResults,
+    is_store_item,
+)
 from microsoft_agents.hosting.core.storage.storage import AsyncStorageBase
 from microsoft_agents.hosting.core.storage._type_aliases import JSON
 from microsoft_agents.hosting.core.storage.error_handling import (
     ignore_error,
     is_status_code_error,
 )
+from microsoft_agents.hosting.core.storage.storage_compatibility import (
+    validate_expected_version,
+    validate_storage_v2_changes,
+    validate_storage_v2_keys,
+    validate_write_mode,
+)
+from microsoft_agents.hosting.core.storage.telemetry import spans
 from microsoft_agents.storage.blob.errors import blob_storage_errors
 
 from .blob_storage_config import BlobStorageConfig
@@ -21,10 +45,10 @@ from .blob_storage_config import BlobStorageConfig
 StoreItemT = TypeVar("StoreItemT", bound=StoreItem)
 
 
-class BlobStorage(AsyncStorageBase):
+class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
     """A Blob Storage provider for storing StoreItem objects in Azure Blob Storage."""
 
-    def __init__(self, config: BlobStorageConfig):
+    def __init__(self, config: BlobStorageConfig[StorageVersionT]):
         """Initialize the BlobStorage with the given configuration.
 
         :param config: BlobStorageConfig object containing the configuration for the blob storage.
@@ -35,12 +59,117 @@ class BlobStorage(AsyncStorageBase):
             raise ValueError(str(blob_storage_errors.BlobContainerNameRequired))
 
         self.config = config
+        if config.storage_version not in (StorageVersion.V1, StorageVersion.V2):
+            raise ValueError(
+                f'Storage version "{config.storage_version}" is not supported.'
+            )
+        self.storage_version = StorageVersion(config.storage_version)
 
         self._blob_service_client: BlobServiceClient = self._create_client()
         self._container_client: ContainerClient = (
             self._blob_service_client.get_container_client(config.container_name)
         )
         self._initialized: bool = False
+
+    @overload
+    async def read(
+        self: "BlobStorage[Literal[StorageVersion.V1]]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> dict[str, StoreItemT]: ...
+
+    @overload
+    async def read(
+        self: "BlobStorage[Literal[StorageVersion.V2]]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> StorageReadResults[StoreItemT]: ...
+
+    @overload
+    async def read(
+        self: "BlobStorage[StorageVersion]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> dict[str, StoreItemT] | StorageReadResults[StoreItemT]: ...
+
+    async def read(
+        self, keys: list[str], *, target_cls: type[StoreItemT], **kwargs
+    ) -> dict[str, StoreItemT] | StorageReadResults[StoreItemT]:
+        """Read items using the selected storage contract."""
+        if self.storage_version == StorageVersion.V1:
+            return await super().read(keys, target_cls=target_cls, **kwargs)
+        with spans.StorageRead(len(keys) if isinstance(keys, list) else 0):
+            return await self._read_v2(keys, target_cls=target_cls)
+
+    @overload
+    async def write(
+        self: "BlobStorage[Literal[StorageVersion.V1]]",
+        changes: dict[str, StoreItem],
+        options: None = None,
+    ) -> None: ...
+
+    @overload
+    async def write(
+        self: "BlobStorage[Literal[StorageVersion.V2]]",
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> StorageWriteResults: ...
+
+    @overload
+    async def write(
+        self: "BlobStorage[StorageVersion]",
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> None | StorageWriteResults: ...
+
+    async def write(
+        self,
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> None | StorageWriteResults:
+        """Write items using the selected storage contract."""
+        if self.storage_version == StorageVersion.V1:
+            return await super().write(changes)
+        with spans.StorageWrite(len(changes) if isinstance(changes, dict) else 0):
+            return await self._write_v2(changes, options)
+
+    @overload
+    async def delete(
+        self: "BlobStorage[Literal[StorageVersion.V1]]",
+        keys: list[str],
+        options: None = None,
+    ) -> None: ...
+
+    @overload
+    async def delete(
+        self: "BlobStorage[Literal[StorageVersion.V2]]",
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> StorageDeleteResults: ...
+
+    @overload
+    async def delete(
+        self: "BlobStorage[StorageVersion]",
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> None | StorageDeleteResults: ...
+
+    async def delete(
+        self,
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> None | StorageDeleteResults:
+        """Delete items using the selected storage contract."""
+        if self.storage_version == StorageVersion.V1:
+            return await super().delete(keys)
+        with spans.StorageDelete(len(keys) if isinstance(keys, list) else 0):
+            return await self._delete_v2(keys, options)
 
     def _create_client(self) -> BlobServiceClient:
         """Creates a BlobServiceClient based on the provided configuration.
@@ -91,7 +220,7 @@ class BlobStorage(AsyncStorageBase):
         item_rep: bytes = await item.readall()
         item_JSON: JSON = json.loads(item_rep)
         try:
-            return key, target_cls.from_json_to_store_item(item_JSON)
+            return key, cast(StoreItemT, target_cls.from_json_to_store_item(item_JSON))
         except AttributeError as error:
             raise TypeError(
                 f"BlobStorage.read_item(): could not deserialize blob item into {target_cls} class. Error: {error}"
@@ -128,6 +257,211 @@ class BlobStorage(AsyncStorageBase):
         await ignore_error(
             self._container_client.delete_blob(blob=key), is_status_code_error(404)
         )
+
+    async def _read_v2(
+        self, keys: list[str], *, target_cls: type[StoreItemT]
+    ) -> StorageReadResults[StoreItemT]:
+        validate_storage_v2_keys(keys)
+        if not keys:
+            return {}
+        await self.initialize()
+        results: StorageReadResults[StoreItemT] = {}
+        for key in keys:
+            blob_client = self._container_client.get_blob_client(key)
+            try:
+                downloader = await blob_client.download_blob(timeout=5)
+                raw = await downloader.readall()
+                value = cast(
+                    StoreItemT,
+                    target_cls.from_json_to_store_item(json.loads(raw)),
+                )
+                results[key] = cast(
+                    StorageReadResult[StoreItemT],
+                    StorageReadResult(
+                        key=key,
+                        status=StorageOperationStatus.SUCCEEDED,
+                        value=value,
+                        version=self._etag_from(downloader.properties),
+                    ),
+                )
+            except Exception as error:  # noqa: BLE001
+                if self._status_code(error) == 404:
+                    results[key] = cast(
+                        StorageReadResult[StoreItemT],
+                        StorageReadResult(
+                            key=key, status=StorageOperationStatus.NOT_FOUND
+                        ),
+                    )
+                else:
+                    raise
+        return results
+
+    async def _write_v2(
+        self,
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None,
+    ) -> StorageWriteResults:
+        validate_storage_v2_changes(changes)
+        if not changes:
+            return {}
+        if any(not is_store_item(value) for value in changes.values()):
+            raise ValueError("Storage V2 values must implement store_item_to_json().")
+        options = options or StorageWriteOptions()
+        validate_write_mode(options.mode)
+        validate_expected_version(options.expected_version)
+        await self.initialize()
+
+        results: StorageWriteResults = {}
+        for key, value in changes.items():
+            blob_client = self._container_client.get_blob_client(key)
+            current_version = await self._get_current_version(blob_client)
+            if (
+                options.mode == StorageWriteMode.CREATE_ONLY
+                and current_version is not None
+            ):
+                results[key] = StorageWriteResult(
+                    key=key,
+                    status=StorageOperationStatus.CONFLICT,
+                    version=current_version,
+                )
+                continue
+            if options.mode == StorageWriteMode.REPLACE and current_version is None:
+                results[key] = StorageWriteResult(
+                    key=key, status=StorageOperationStatus.NOT_FOUND
+                )
+                continue
+            if (
+                options.expected_version is not None
+                and options.expected_version != current_version
+            ):
+                results[key] = StorageWriteResult(
+                    key=key,
+                    status=StorageOperationStatus.CONDITION_NOT_MET,
+                    version=current_version,
+                )
+                continue
+
+            payload = json.dumps(value.store_item_to_json()).encode("utf-8")
+            try:
+                upload_options = {
+                    "overwrite": options.mode != StorageWriteMode.CREATE_ONLY
+                }
+                condition_version = options.expected_version
+                if options.mode == StorageWriteMode.REPLACE:
+                    condition_version = current_version
+                if condition_version is not None:
+                    upload_options.update(
+                        {
+                            "etag": condition_version,
+                            "match_condition": MatchConditions.IfNotModified,
+                        }
+                    )
+                response = await blob_client.upload_blob(
+                    BytesIO(payload), length=len(payload), **upload_options
+                )
+                results[key] = StorageWriteResult(
+                    key=key,
+                    status=StorageOperationStatus.SUCCEEDED,
+                    version=self._etag_from(response),
+                )
+            except Exception as error:  # noqa: BLE001
+                status_code = self._status_code(error)
+                if options.mode == StorageWriteMode.CREATE_ONLY and status_code in (
+                    409,
+                    412,
+                ):
+                    results[key] = StorageWriteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONFLICT,
+                        version=await self._get_current_version(blob_client),
+                    )
+                elif status_code == 404:
+                    results[key] = StorageWriteResult(
+                        key=key, status=StorageOperationStatus.NOT_FOUND
+                    )
+                elif status_code == 412:
+                    results[key] = StorageWriteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONDITION_NOT_MET,
+                        version=await self._get_current_version(blob_client),
+                    )
+                else:
+                    raise
+        return results
+
+    async def _delete_v2(
+        self,
+        keys: list[str],
+        options: StorageDeleteOptions | None,
+    ) -> StorageDeleteResults:
+        validate_storage_v2_keys(keys)
+        if not keys:
+            return {}
+        options = options or StorageDeleteOptions()
+        validate_expected_version(options.expected_version)
+        await self.initialize()
+
+        results: StorageDeleteResults = {}
+        for key in keys:
+            blob_client = self._container_client.get_blob_client(key)
+            current_version = await self._get_current_version(blob_client)
+            if current_version is None:
+                results[key] = StorageDeleteResult(
+                    key=key, status=StorageOperationStatus.NOT_FOUND
+                )
+                continue
+            if (
+                options.expected_version is not None
+                and options.expected_version != current_version
+            ):
+                results[key] = StorageDeleteResult(
+                    key=key,
+                    status=StorageOperationStatus.CONDITION_NOT_MET,
+                    version=current_version,
+                )
+                continue
+            try:
+                await blob_client.delete_blob(
+                    etag=current_version,
+                    match_condition=MatchConditions.IfNotModified,
+                )
+                results[key] = StorageDeleteResult(
+                    key=key,
+                    status=StorageOperationStatus.SUCCEEDED,
+                    version=current_version,
+                )
+            except Exception as error:  # noqa: BLE001
+                if self._status_code(error) == 404:
+                    results[key] = StorageDeleteResult(
+                        key=key, status=StorageOperationStatus.NOT_FOUND
+                    )
+                elif self._status_code(error) == 412:
+                    results[key] = StorageDeleteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONDITION_NOT_MET,
+                        version=await self._get_current_version(blob_client),
+                    )
+                else:
+                    raise
+        return results
+
+    async def _get_current_version(self, blob_client) -> str | None:
+        try:
+            return self._etag_from(await blob_client.get_blob_properties())
+        except Exception as error:  # noqa: BLE001
+            if self._status_code(error) == 404:
+                return None
+            raise
+
+    @staticmethod
+    def _etag_from(properties) -> str | None:
+        if isinstance(properties, dict):
+            return properties.get("etag")
+        return getattr(properties, "etag", None)
+
+    @staticmethod
+    def _status_code(error: Exception) -> int | None:
+        return getattr(error, "status_code", None)
 
     async def _close(self) -> None:
         """Cleans up the storage resources."""

--- a/libraries/microsoft-agents-storage-blob/microsoft_agents/storage/blob/blob_storage.py
+++ b/libraries/microsoft-agents-storage-blob/microsoft_agents/storage/blob/blob_storage.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Generic, Literal, TypeVar, cast, overload
 from io import BytesIO
@@ -135,6 +136,8 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
     ) -> None | StorageWriteResults:
         """Write items using the selected storage contract."""
         if self.storage_version == StorageVersion.V1:
+            if options is not None:
+                raise ValueError("Storage write options require Storage V2.")
             return await super().write(changes)
         with spans.StorageWrite(len(changes) if isinstance(changes, dict) else 0):
             return await self._write_v2(changes, options)
@@ -167,6 +170,8 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
     ) -> None | StorageDeleteResults:
         """Delete items using the selected storage contract."""
         if self.storage_version == StorageVersion.V1:
+            if options is not None:
+                raise ValueError("Storage delete options require Storage V2.")
             return await super().delete(keys)
         with spans.StorageDelete(len(keys) if isinstance(keys, list) else 0):
             return await self._delete_v2(keys, options)
@@ -265,8 +270,8 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
         if not keys:
             return {}
         await self.initialize()
-        results: StorageReadResults[StoreItemT] = {}
-        for key in keys:
+
+        async def read_one(key: str) -> StorageReadResult[StoreItemT]:
             blob_client = self._container_client.get_blob_client(key)
             try:
                 downloader = await blob_client.download_blob(timeout=5)
@@ -275,7 +280,7 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                     StoreItemT,
                     target_cls.from_json_to_store_item(json.loads(raw)),
                 )
-                results[key] = cast(
+                return cast(
                     StorageReadResult[StoreItemT],
                     StorageReadResult(
                         key=key,
@@ -286,7 +291,7 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                 )
             except Exception as error:  # noqa: BLE001
                 if self._status_code(error) == 404:
-                    results[key] = cast(
+                    return cast(
                         StorageReadResult[StoreItemT],
                         StorageReadResult(
                             key=key, status=StorageOperationStatus.NOT_FOUND
@@ -294,7 +299,9 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                     )
                 else:
                     raise
-        return results
+
+        results = await asyncio.gather(*(read_one(key) for key in keys))
+        return {result.key: result for result in results}
 
     async def _write_v2(
         self,
@@ -306,48 +313,47 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
             return {}
         if any(not is_store_item(value) for value in changes.values()):
             raise ValueError("Storage V2 values must implement store_item_to_json().")
-        options = options or StorageWriteOptions()
-        validate_write_mode(options.mode)
-        validate_expected_version(options.expected_version)
+        write_options = options or StorageWriteOptions()
+        validate_write_mode(write_options.mode)
+        validate_expected_version(write_options.expected_version)
         await self.initialize()
 
-        results: StorageWriteResults = {}
-        for key, value in changes.items():
+        async def write_one(key: str, value: StoreItem) -> StorageWriteResult:
             blob_client = self._container_client.get_blob_client(key)
             current_version = await self._get_current_version(blob_client)
             if (
-                options.mode == StorageWriteMode.CREATE_ONLY
+                write_options.mode == StorageWriteMode.CREATE_ONLY
                 and current_version is not None
             ):
-                results[key] = StorageWriteResult(
+                return StorageWriteResult(
                     key=key,
                     status=StorageOperationStatus.CONFLICT,
                     version=current_version,
                 )
-                continue
-            if options.mode == StorageWriteMode.REPLACE and current_version is None:
-                results[key] = StorageWriteResult(
+            if (
+                write_options.mode == StorageWriteMode.REPLACE
+                and current_version is None
+            ):
+                return StorageWriteResult(
                     key=key, status=StorageOperationStatus.NOT_FOUND
                 )
-                continue
             if (
-                options.expected_version is not None
-                and options.expected_version != current_version
+                write_options.expected_version is not None
+                and write_options.expected_version != current_version
             ):
-                results[key] = StorageWriteResult(
+                return StorageWriteResult(
                     key=key,
                     status=StorageOperationStatus.CONDITION_NOT_MET,
                     version=current_version,
                 )
-                continue
 
             payload = json.dumps(value.store_item_to_json()).encode("utf-8")
             try:
                 upload_options = {
-                    "overwrite": options.mode != StorageWriteMode.CREATE_ONLY
+                    "overwrite": write_options.mode != StorageWriteMode.CREATE_ONLY
                 }
-                condition_version = options.expected_version
-                if options.mode == StorageWriteMode.REPLACE:
+                condition_version = write_options.expected_version
+                if write_options.mode == StorageWriteMode.REPLACE:
                     condition_version = current_version
                 if condition_version is not None:
                     upload_options.update(
@@ -359,35 +365,42 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                 response = await blob_client.upload_blob(
                     BytesIO(payload), length=len(payload), **upload_options
                 )
-                results[key] = StorageWriteResult(
+                return StorageWriteResult(
                     key=key,
                     status=StorageOperationStatus.SUCCEEDED,
                     version=self._etag_from(response),
                 )
             except Exception as error:  # noqa: BLE001
                 status_code = self._status_code(error)
-                if options.mode == StorageWriteMode.CREATE_ONLY and status_code in (
-                    409,
-                    412,
+                if (
+                    write_options.mode == StorageWriteMode.CREATE_ONLY
+                    and status_code
+                    in (
+                        409,
+                        412,
+                    )
                 ):
-                    results[key] = StorageWriteResult(
+                    return StorageWriteResult(
                         key=key,
                         status=StorageOperationStatus.CONFLICT,
                         version=await self._get_current_version(blob_client),
                     )
-                elif status_code == 404:
-                    results[key] = StorageWriteResult(
+                if status_code == 404:
+                    return StorageWriteResult(
                         key=key, status=StorageOperationStatus.NOT_FOUND
                     )
-                elif status_code == 412:
-                    results[key] = StorageWriteResult(
+                if status_code == 412:
+                    return StorageWriteResult(
                         key=key,
                         status=StorageOperationStatus.CONDITION_NOT_MET,
                         version=await self._get_current_version(blob_client),
                     )
-                else:
-                    raise
-        return results
+                raise
+
+        results = await asyncio.gather(
+            *(write_one(key, value) for key, value in changes.items())
+        )
+        return {result.key: result for result in results}
 
     async def _delete_v2(
         self,
@@ -397,53 +410,51 @@ class BlobStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
         validate_storage_v2_keys(keys)
         if not keys:
             return {}
-        options = options or StorageDeleteOptions()
-        validate_expected_version(options.expected_version)
+        delete_options = options or StorageDeleteOptions()
+        validate_expected_version(delete_options.expected_version)
         await self.initialize()
 
-        results: StorageDeleteResults = {}
-        for key in keys:
+        async def delete_one(key: str) -> StorageDeleteResult:
             blob_client = self._container_client.get_blob_client(key)
             current_version = await self._get_current_version(blob_client)
             if current_version is None:
-                results[key] = StorageDeleteResult(
+                return StorageDeleteResult(
                     key=key, status=StorageOperationStatus.NOT_FOUND
                 )
-                continue
             if (
-                options.expected_version is not None
-                and options.expected_version != current_version
+                delete_options.expected_version is not None
+                and delete_options.expected_version != current_version
             ):
-                results[key] = StorageDeleteResult(
+                return StorageDeleteResult(
                     key=key,
                     status=StorageOperationStatus.CONDITION_NOT_MET,
                     version=current_version,
                 )
-                continue
             try:
                 await blob_client.delete_blob(
                     etag=current_version,
                     match_condition=MatchConditions.IfNotModified,
                 )
-                results[key] = StorageDeleteResult(
+                return StorageDeleteResult(
                     key=key,
                     status=StorageOperationStatus.SUCCEEDED,
                     version=current_version,
                 )
             except Exception as error:  # noqa: BLE001
                 if self._status_code(error) == 404:
-                    results[key] = StorageDeleteResult(
+                    return StorageDeleteResult(
                         key=key, status=StorageOperationStatus.NOT_FOUND
                     )
-                elif self._status_code(error) == 412:
-                    results[key] = StorageDeleteResult(
+                if self._status_code(error) == 412:
+                    return StorageDeleteResult(
                         key=key,
                         status=StorageOperationStatus.CONDITION_NOT_MET,
                         version=await self._get_current_version(blob_client),
                     )
-                else:
-                    raise
-        return results
+                raise
+
+        results = await asyncio.gather(*(delete_one(key) for key in keys))
+        return {result.key: result for result in results}
 
     async def _get_current_version(self, blob_client) -> str | None:
         try:

--- a/libraries/microsoft-agents-storage-blob/microsoft_agents/storage/blob/blob_storage_config.py
+++ b/libraries/microsoft-agents-storage-blob/microsoft_agents/storage/blob/blob_storage_config.py
@@ -1,7 +1,10 @@
+from typing import Generic
+
 from azure.core.credentials_async import AsyncTokenCredential
+from microsoft_agents.hosting.core.storage import StorageVersion, StorageVersionT
 
 
-class BlobStorageConfig:
+class BlobStorageConfig(Generic[StorageVersionT]):
     """Configuration settings for BlobStorage."""
 
     def __init__(
@@ -10,6 +13,7 @@ class BlobStorageConfig:
         connection_string: str = "",
         url: str = "",
         credential: AsyncTokenCredential | None = None,
+        storage_version: StorageVersionT = StorageVersion.V1,
     ):
         """Configuration settings for BlobStorage.
 
@@ -24,3 +28,4 @@ class BlobStorageConfig:
         self.connection_string: str = connection_string
         self.url: str = url
         self.credential: AsyncTokenCredential | None = credential
+        self.storage_version = StorageVersion(storage_version)

--- a/libraries/microsoft-agents-storage-blob/readme.md
+++ b/libraries/microsoft-agents-storage-blob/readme.md
@@ -179,6 +179,7 @@ pip install microsoft-agents-storage-blob
 | `connection_string` | `str` | No* | Storage account connection string |
 | `url` | `str` | No* | Blob service URL (e.g., `https://account.blob.core.windows.net`) |
 | `credential` | `TokenCredential` | No** | Azure credential for authentication |
+| `storage_version` | `StorageVersion` | No | Storage contract version; defaults to `StorageVersion.V1` |
 
 *Either `connection_string` OR (`url` + `credential`) must be provided  
 **Required when using `url`

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
@@ -1,13 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from typing import TypeVar
+from typing import Generic, Literal, TypeVar, cast, overload
 import asyncio
 
 from azure.cosmos import (
     documents,
     CosmosDict,
 )
+from azure.core import MatchConditions
 from azure.cosmos.aio import (
     ContainerProxy,
     CosmosClient,
@@ -16,9 +17,33 @@ from azure.cosmos.aio import (
 import azure.cosmos.exceptions as cosmos_exceptions
 from azure.cosmos.partition_key import NonePartitionKeyValue
 
-from microsoft_agents.hosting.core.storage import AsyncStorageBase, StoreItem
+from microsoft_agents.hosting.core.storage import (
+    AsyncStorageBase,
+    StoreItem,
+    StorageDeleteOptions,
+    StorageDeleteResult,
+    StorageDeleteResults,
+    StorageOperationStatus,
+    StorageReadResult,
+    StorageReadResults,
+    StorageV2,
+    StorageVersion,
+    StorageVersionT,
+    StorageWriteMode,
+    StorageWriteOptions,
+    StorageWriteResult,
+    StorageWriteResults,
+    is_store_item,
+)
 from microsoft_agents.hosting.core.storage._type_aliases import JSON
 from microsoft_agents.hosting.core.storage.error_handling import ignore_error
+from microsoft_agents.hosting.core.storage.storage_compatibility import (
+    validate_expected_version,
+    validate_storage_v2_changes,
+    validate_storage_v2_keys,
+    validate_write_mode,
+)
+from microsoft_agents.hosting.core.storage.telemetry import spans
 from microsoft_agents.storage.cosmos.errors import storage_errors
 
 from .cosmos_db_storage_config import CosmosDBStorageConfig
@@ -31,10 +56,10 @@ cosmos_resource_not_found = lambda err: isinstance(
 )
 
 
-class CosmosDBStorage(AsyncStorageBase):
+class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
     """A CosmosDB based storage provider using partitioning"""
 
-    def __init__(self, config: CosmosDBStorageConfig):
+    def __init__(self, config: CosmosDBStorageConfig[StorageVersionT]):
         """Create the storage object.
 
         :param config:
@@ -43,13 +68,118 @@ class CosmosDBStorage(AsyncStorageBase):
 
         CosmosDBStorageConfig.validate_cosmos_db_config(config)
 
-        self._config: CosmosDBStorageConfig = config
+        self._config: CosmosDBStorageConfig[StorageVersionT] = config
+        if config.storage_version not in (StorageVersion.V1, StorageVersion.V2):
+            raise ValueError(
+                f'Storage version "{config.storage_version}" is not supported.'
+            )
+        self.storage_version = StorageVersion(config.storage_version)
         self._client: CosmosClient = self._create_client()
         self._database: DatabaseProxy | None = None
         self._container: ContainerProxy | None = None
         self._compatability_mode_partition_key: bool = False
         # Lock used for synchronizing container creation
         self._lock: asyncio.Lock = asyncio.Lock()
+
+    @overload
+    async def read(
+        self: "CosmosDBStorage[Literal[StorageVersion.V1]]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> dict[str, StoreItemT]: ...
+
+    @overload
+    async def read(
+        self: "CosmosDBStorage[Literal[StorageVersion.V2]]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> StorageReadResults[StoreItemT]: ...
+
+    @overload
+    async def read(
+        self: "CosmosDBStorage[StorageVersion]",
+        keys: list[str],
+        *,
+        target_cls: type[StoreItemT],
+        **kwargs,
+    ) -> dict[str, StoreItemT] | StorageReadResults[StoreItemT]: ...
+
+    async def read(
+        self, keys: list[str], *, target_cls: type[StoreItemT], **kwargs
+    ) -> dict[str, StoreItemT] | StorageReadResults[StoreItemT]:
+        """Read items using the selected storage contract."""
+        if self.storage_version == StorageVersion.V1:
+            return await super().read(keys, target_cls=target_cls, **kwargs)
+        with spans.StorageRead(len(keys) if isinstance(keys, list) else 0):
+            return await self._read_v2(keys, target_cls=target_cls)
+
+    @overload
+    async def write(
+        self: "CosmosDBStorage[Literal[StorageVersion.V1]]",
+        changes: dict[str, StoreItem],
+        options: None = None,
+    ) -> None: ...
+
+    @overload
+    async def write(
+        self: "CosmosDBStorage[Literal[StorageVersion.V2]]",
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> StorageWriteResults: ...
+
+    @overload
+    async def write(
+        self: "CosmosDBStorage[StorageVersion]",
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> None | StorageWriteResults: ...
+
+    async def write(
+        self,
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None = None,
+    ) -> None | StorageWriteResults:
+        """Write items using the selected storage contract."""
+        if self.storage_version == StorageVersion.V1:
+            return await super().write(changes)
+        with spans.StorageWrite(len(changes) if isinstance(changes, dict) else 0):
+            return await self._write_v2(changes, options)
+
+    @overload
+    async def delete(
+        self: "CosmosDBStorage[Literal[StorageVersion.V1]]",
+        keys: list[str],
+        options: None = None,
+    ) -> None: ...
+
+    @overload
+    async def delete(
+        self: "CosmosDBStorage[Literal[StorageVersion.V2]]",
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> StorageDeleteResults: ...
+
+    @overload
+    async def delete(
+        self: "CosmosDBStorage[StorageVersion]",
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> None | StorageDeleteResults: ...
+
+    async def delete(
+        self,
+        keys: list[str],
+        options: StorageDeleteOptions | None = None,
+    ) -> None | StorageDeleteResults:
+        """Delete items using the selected storage contract."""
+        if self.storage_version == StorageVersion.V1:
+            return await super().delete(keys)
+        with spans.StorageDelete(len(keys) if isinstance(keys, list) else 0):
+            return await self._delete_v2(keys, options)
 
     def _create_client(self) -> CosmosClient:
         """Create a CosmosClient based on the configuration.
@@ -119,7 +249,9 @@ class CosmosDBStorage(AsyncStorageBase):
         doc: JSON | None = read_item_response.get("document")
         if doc is None:
             return read_item_response["realId"], None
-        return read_item_response["realId"], target_cls.from_json_to_store_item(doc)
+        return read_item_response["realId"], cast(
+            StoreItemT, target_cls.from_json_to_store_item(doc)
+        )
 
     async def _write_item(self, key: str, item: StoreItem) -> None:
         """Write an item to the storage.
@@ -157,6 +289,214 @@ class CosmosDBStorage(AsyncStorageBase):
             ),
             cosmos_resource_not_found,
         )
+
+    async def _read_v2(
+        self, keys: list[str], *, target_cls: type[StoreItemT]
+    ) -> StorageReadResults[StoreItemT]:
+        validate_storage_v2_keys(keys)
+        if not keys:
+            return {}
+        await self.initialize()
+        results: StorageReadResults[StoreItemT] = {}
+        for key in keys:
+            try:
+                document = await self._read_document(key)
+                results[key] = cast(
+                    StorageReadResult[StoreItemT],
+                    StorageReadResult(
+                        key=key,
+                        status=StorageOperationStatus.SUCCEEDED,
+                        value=cast(
+                            StoreItemT,
+                            target_cls.from_json_to_store_item(document["document"]),
+                        ),
+                        version=document.get("_etag"),
+                    ),
+                )
+            except Exception as error:  # noqa: BLE001
+                if self._status_code(error) == 404:
+                    results[key] = cast(
+                        StorageReadResult[StoreItemT],
+                        StorageReadResult(
+                            key=key, status=StorageOperationStatus.NOT_FOUND
+                        ),
+                    )
+                else:
+                    raise
+        return results
+
+    async def _write_v2(
+        self,
+        changes: dict[str, StoreItem],
+        options: StorageWriteOptions | None,
+    ) -> StorageWriteResults:
+        validate_storage_v2_changes(changes)
+        if not changes:
+            return {}
+        if any(not is_store_item(value) for value in changes.values()):
+            raise ValueError("Storage V2 values must implement store_item_to_json().")
+        options = options or StorageWriteOptions()
+        validate_write_mode(options.mode)
+        validate_expected_version(options.expected_version)
+        await self.initialize()
+
+        results: StorageWriteResults = {}
+        for key, value in changes.items():
+            current = await self._try_read_document(key)
+            current_version = current.get("_etag") if current else None
+            if options.mode == StorageWriteMode.CREATE_ONLY and current is not None:
+                results[key] = StorageWriteResult(
+                    key=key,
+                    status=StorageOperationStatus.CONFLICT,
+                    version=current_version,
+                )
+                continue
+            if options.mode == StorageWriteMode.REPLACE and current is None:
+                results[key] = StorageWriteResult(
+                    key=key, status=StorageOperationStatus.NOT_FOUND
+                )
+                continue
+            if (
+                options.expected_version is not None
+                and options.expected_version != current_version
+            ):
+                results[key] = StorageWriteResult(
+                    key=key,
+                    status=StorageOperationStatus.CONDITION_NOT_MET,
+                    version=current_version,
+                )
+                continue
+
+            escaped_key = self._sanitize(key)
+            document = {
+                "id": escaped_key,
+                "realId": key,
+                "document": value.store_item_to_json(),
+            }
+            try:
+                if options.mode == StorageWriteMode.CREATE_ONLY:
+                    response = await self._container.create_item(body=document)
+                elif options.mode == StorageWriteMode.REPLACE:
+                    response = await self._container.replace_item(
+                        escaped_key,
+                        document,
+                        etag=current_version,
+                        match_condition=MatchConditions.IfNotModified,
+                    )
+                elif options.expected_version is not None:
+                    response = await self._container.upsert_item(
+                        body=document,
+                        etag=options.expected_version,
+                        match_condition=MatchConditions.IfNotModified,
+                    )
+                else:
+                    response = await self._container.upsert_item(body=document)
+                results[key] = StorageWriteResult(
+                    key=key,
+                    status=StorageOperationStatus.SUCCEEDED,
+                    version=response.get("_etag"),
+                )
+            except Exception as error:  # noqa: BLE001
+                status_code = self._status_code(error)
+                if options.mode == StorageWriteMode.CREATE_ONLY and status_code == 409:
+                    results[key] = StorageWriteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONFLICT,
+                        version=(await self._try_read_document(key) or {}).get("_etag"),
+                    )
+                elif status_code == 404:
+                    results[key] = StorageWriteResult(
+                        key=key, status=StorageOperationStatus.NOT_FOUND
+                    )
+                elif status_code == 412:
+                    results[key] = StorageWriteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONDITION_NOT_MET,
+                        version=(await self._try_read_document(key) or {}).get("_etag"),
+                    )
+                else:
+                    raise
+        return results
+
+    async def _delete_v2(
+        self,
+        keys: list[str],
+        options: StorageDeleteOptions | None,
+    ) -> StorageDeleteResults:
+        validate_storage_v2_keys(keys)
+        if not keys:
+            return {}
+        options = options or StorageDeleteOptions()
+        validate_expected_version(options.expected_version)
+        await self.initialize()
+
+        results: StorageDeleteResults = {}
+        for key in keys:
+            current = await self._try_read_document(key)
+            if current is None:
+                results[key] = StorageDeleteResult(
+                    key=key, status=StorageOperationStatus.NOT_FOUND
+                )
+                continue
+            current_version = current.get("_etag")
+            if (
+                options.expected_version is not None
+                and options.expected_version != current_version
+            ):
+                results[key] = StorageDeleteResult(
+                    key=key,
+                    status=StorageOperationStatus.CONDITION_NOT_MET,
+                    version=current_version,
+                )
+                continue
+            escaped_key = self._sanitize(key)
+            try:
+                await self._container.delete_item(
+                    escaped_key,
+                    self._get_partition_key(escaped_key),
+                    etag=current_version,
+                    match_condition=MatchConditions.IfNotModified,
+                )
+                results[key] = StorageDeleteResult(
+                    key=key,
+                    status=StorageOperationStatus.SUCCEEDED,
+                    version=current_version,
+                )
+            except Exception as error:  # noqa: BLE001
+                status_code = self._status_code(error)
+                if status_code == 404:
+                    results[key] = StorageDeleteResult(
+                        key=key, status=StorageOperationStatus.NOT_FOUND
+                    )
+                elif status_code == 412:
+                    results[key] = StorageDeleteResult(
+                        key=key,
+                        status=StorageOperationStatus.CONDITION_NOT_MET,
+                        version=(await self._try_read_document(key) or {}).get("_etag"),
+                    )
+                else:
+                    raise
+        return results
+
+    async def _read_document(self, key: str) -> CosmosDict:
+        if key == "":
+            raise ValueError(str(storage_errors.CosmosDbKeyCannotBeEmpty))
+        escaped_key = self._sanitize(key)
+        return await self._container.read_item(
+            escaped_key, self._get_partition_key(escaped_key)
+        )
+
+    async def _try_read_document(self, key: str) -> CosmosDict | None:
+        try:
+            return await self._read_document(key)
+        except Exception as error:  # noqa: BLE001
+            if self._status_code(error) == 404:
+                return None
+            raise
+
+    @staticmethod
+    def _status_code(error: Exception) -> int | None:
+        return getattr(error, "status_code", None)
 
     async def _create_container(self) -> None:
         """Create the container if it does not exist."""

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
@@ -387,6 +387,7 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                         document,
                         etag=current_version,
                         match_condition=MatchConditions.IfNotModified,
+                        partition_key=self._get_partition_key(escaped_key),
                     )
                 elif write_options.expected_version is not None:
                     response = await self._container.upsert_item(

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage.py
@@ -145,6 +145,8 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
     ) -> None | StorageWriteResults:
         """Write items using the selected storage contract."""
         if self.storage_version == StorageVersion.V1:
+            if options is not None:
+                raise ValueError("Storage write options require Storage V2.")
             return await super().write(changes)
         with spans.StorageWrite(len(changes) if isinstance(changes, dict) else 0):
             return await self._write_v2(changes, options)
@@ -177,6 +179,8 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
     ) -> None | StorageDeleteResults:
         """Delete items using the selected storage contract."""
         if self.storage_version == StorageVersion.V1:
+            if options is not None:
+                raise ValueError("Storage delete options require Storage V2.")
             return await super().delete(keys)
         with spans.StorageDelete(len(keys) if isinstance(keys, list) else 0):
             return await self._delete_v2(keys, options)
@@ -297,11 +301,11 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
         if not keys:
             return {}
         await self.initialize()
-        results: StorageReadResults[StoreItemT] = {}
-        for key in keys:
+
+        async def read_one(key: str) -> StorageReadResult[StoreItemT]:
             try:
                 document = await self._read_document(key)
-                results[key] = cast(
+                return cast(
                     StorageReadResult[StoreItemT],
                     StorageReadResult(
                         key=key,
@@ -315,7 +319,7 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                 )
             except Exception as error:  # noqa: BLE001
                 if self._status_code(error) == 404:
-                    results[key] = cast(
+                    return cast(
                         StorageReadResult[StoreItemT],
                         StorageReadResult(
                             key=key, status=StorageOperationStatus.NOT_FOUND
@@ -323,7 +327,9 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                     )
                 else:
                     raise
-        return results
+
+        results = await asyncio.gather(*(read_one(key) for key in keys))
+        return {result.key: result for result in results}
 
     async def _write_v2(
         self,
@@ -335,37 +341,36 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
             return {}
         if any(not is_store_item(value) for value in changes.values()):
             raise ValueError("Storage V2 values must implement store_item_to_json().")
-        options = options or StorageWriteOptions()
-        validate_write_mode(options.mode)
-        validate_expected_version(options.expected_version)
+        write_options = options or StorageWriteOptions()
+        validate_write_mode(write_options.mode)
+        validate_expected_version(write_options.expected_version)
         await self.initialize()
 
-        results: StorageWriteResults = {}
-        for key, value in changes.items():
+        async def write_one(key: str, value: StoreItem) -> StorageWriteResult:
             current = await self._try_read_document(key)
             current_version = current.get("_etag") if current else None
-            if options.mode == StorageWriteMode.CREATE_ONLY and current is not None:
-                results[key] = StorageWriteResult(
+            if (
+                write_options.mode == StorageWriteMode.CREATE_ONLY
+                and current is not None
+            ):
+                return StorageWriteResult(
                     key=key,
                     status=StorageOperationStatus.CONFLICT,
                     version=current_version,
                 )
-                continue
-            if options.mode == StorageWriteMode.REPLACE and current is None:
-                results[key] = StorageWriteResult(
+            if write_options.mode == StorageWriteMode.REPLACE and current is None:
+                return StorageWriteResult(
                     key=key, status=StorageOperationStatus.NOT_FOUND
                 )
-                continue
             if (
-                options.expected_version is not None
-                and options.expected_version != current_version
+                write_options.expected_version is not None
+                and write_options.expected_version != current_version
             ):
-                results[key] = StorageWriteResult(
+                return StorageWriteResult(
                     key=key,
                     status=StorageOperationStatus.CONDITION_NOT_MET,
                     version=current_version,
                 )
-                continue
 
             escaped_key = self._sanitize(key)
             document = {
@@ -374,49 +379,55 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                 "document": value.store_item_to_json(),
             }
             try:
-                if options.mode == StorageWriteMode.CREATE_ONLY:
+                if write_options.mode == StorageWriteMode.CREATE_ONLY:
                     response = await self._container.create_item(body=document)
-                elif options.mode == StorageWriteMode.REPLACE:
+                elif write_options.mode == StorageWriteMode.REPLACE:
                     response = await self._container.replace_item(
                         escaped_key,
                         document,
                         etag=current_version,
                         match_condition=MatchConditions.IfNotModified,
                     )
-                elif options.expected_version is not None:
+                elif write_options.expected_version is not None:
                     response = await self._container.upsert_item(
                         body=document,
-                        etag=options.expected_version,
+                        etag=write_options.expected_version,
                         match_condition=MatchConditions.IfNotModified,
                     )
                 else:
                     response = await self._container.upsert_item(body=document)
-                results[key] = StorageWriteResult(
+                return StorageWriteResult(
                     key=key,
                     status=StorageOperationStatus.SUCCEEDED,
                     version=response.get("_etag"),
                 )
             except Exception as error:  # noqa: BLE001
                 status_code = self._status_code(error)
-                if options.mode == StorageWriteMode.CREATE_ONLY and status_code == 409:
-                    results[key] = StorageWriteResult(
+                if (
+                    write_options.mode == StorageWriteMode.CREATE_ONLY
+                    and status_code == 409
+                ):
+                    return StorageWriteResult(
                         key=key,
                         status=StorageOperationStatus.CONFLICT,
                         version=(await self._try_read_document(key) or {}).get("_etag"),
                     )
-                elif status_code == 404:
-                    results[key] = StorageWriteResult(
+                if status_code == 404:
+                    return StorageWriteResult(
                         key=key, status=StorageOperationStatus.NOT_FOUND
                     )
-                elif status_code == 412:
-                    results[key] = StorageWriteResult(
+                if status_code == 412:
+                    return StorageWriteResult(
                         key=key,
                         status=StorageOperationStatus.CONDITION_NOT_MET,
                         version=(await self._try_read_document(key) or {}).get("_etag"),
                     )
-                else:
-                    raise
-        return results
+                raise
+
+        results = await asyncio.gather(
+            *(write_one(key, value) for key, value in changes.items())
+        )
+        return {result.key: result for result in results}
 
     async def _delete_v2(
         self,
@@ -426,29 +437,26 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
         validate_storage_v2_keys(keys)
         if not keys:
             return {}
-        options = options or StorageDeleteOptions()
-        validate_expected_version(options.expected_version)
+        delete_options = options or StorageDeleteOptions()
+        validate_expected_version(delete_options.expected_version)
         await self.initialize()
 
-        results: StorageDeleteResults = {}
-        for key in keys:
+        async def delete_one(key: str) -> StorageDeleteResult:
             current = await self._try_read_document(key)
             if current is None:
-                results[key] = StorageDeleteResult(
+                return StorageDeleteResult(
                     key=key, status=StorageOperationStatus.NOT_FOUND
                 )
-                continue
             current_version = current.get("_etag")
             if (
-                options.expected_version is not None
-                and options.expected_version != current_version
+                delete_options.expected_version is not None
+                and delete_options.expected_version != current_version
             ):
-                results[key] = StorageDeleteResult(
+                return StorageDeleteResult(
                     key=key,
                     status=StorageOperationStatus.CONDITION_NOT_MET,
                     version=current_version,
                 )
-                continue
             escaped_key = self._sanitize(key)
             try:
                 await self._container.delete_item(
@@ -457,7 +465,7 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
                     etag=current_version,
                     match_condition=MatchConditions.IfNotModified,
                 )
-                results[key] = StorageDeleteResult(
+                return StorageDeleteResult(
                     key=key,
                     status=StorageOperationStatus.SUCCEEDED,
                     version=current_version,
@@ -465,18 +473,19 @@ class CosmosDBStorage(AsyncStorageBase, StorageV2, Generic[StorageVersionT]):
             except Exception as error:  # noqa: BLE001
                 status_code = self._status_code(error)
                 if status_code == 404:
-                    results[key] = StorageDeleteResult(
+                    return StorageDeleteResult(
                         key=key, status=StorageOperationStatus.NOT_FOUND
                     )
-                elif status_code == 412:
-                    results[key] = StorageDeleteResult(
+                if status_code == 412:
+                    return StorageDeleteResult(
                         key=key,
                         status=StorageOperationStatus.CONDITION_NOT_MET,
                         version=(await self._try_read_document(key) or {}).get("_etag"),
                     )
-                else:
-                    raise
-        return results
+                raise
+
+        results = await asyncio.gather(*(delete_one(key) for key in keys))
+        return {result.key: result for result in results}
 
     async def _read_document(self, key: str) -> CosmosDict:
         if key == "":

--- a/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
+++ b/libraries/microsoft-agents-storage-cosmos/microsoft_agents/storage/cosmos/cosmos_db_storage_config.py
@@ -1,12 +1,14 @@
 import json
+from typing import Any, Generic
 
 from azure.core.credentials_async import AsyncTokenCredential
+from microsoft_agents.hosting.core.storage import StorageVersion, StorageVersionT
 from microsoft_agents.storage.cosmos.errors import storage_errors
 
 from .key_ops import sanitize_key
 
 
-class CosmosDBStorageConfig:
+class CosmosDBStorageConfig(Generic[StorageVersionT]):
     """The class for partitioned CosmosDB configuration for the Azure Bot Framework."""
 
     def __init__(
@@ -21,6 +23,7 @@ class CosmosDBStorageConfig:
         compatibility_mode: bool = False,
         url: str = "",
         credential: AsyncTokenCredential | None = None,
+        storage_version: StorageVersionT = StorageVersion.V1,
         **kwargs,
     ):
         """Create the Config object.
@@ -62,9 +65,12 @@ class CosmosDBStorageConfig:
         )
         self.url = url or kwargs.get("url", "")
         self.credential: AsyncTokenCredential | None = credential
+        self.storage_version = StorageVersion(storage_version)
 
     @staticmethod
-    def validate_cosmos_db_config(config: "CosmosDBStorageConfig") -> None:
+    def validate_cosmos_db_config(
+        config: "CosmosDBStorageConfig[Any]",
+    ) -> None:
         """Validate the CosmosDBConfig object.
 
         This is used prior to the creation of the CosmosDBStorage object."""
@@ -78,7 +84,7 @@ class CosmosDBStorageConfig:
         CosmosDBStorageConfig._validate_suffix(config)
 
     @staticmethod
-    def _validate_suffix(config: "CosmosDBStorageConfig") -> None:
+    def _validate_suffix(config: "CosmosDBStorageConfig[Any]") -> None:
         if config.key_suffix:
             if config.compatibility_mode:
                 raise ValueError(str(storage_errors.CosmosDbCompatibilityModeRequired))

--- a/libraries/microsoft-agents-storage-cosmos/readme.md
+++ b/libraries/microsoft-agents-storage-cosmos/readme.md
@@ -172,6 +172,12 @@ Additionally we provide a Copilot Studio Client, to interact with Agents created
 pip install microsoft-agents-storage-cosmos
 ```
 
+## Storage version
+
+`CosmosDBStorageConfig` uses V1 by default. Set
+`storage_version=StorageVersion.V2` for per-key operation results and
+optimistic concurrency tokens.
+
 
 ## Environment Setup
 

--- a/test_samples/app_style/README.md
+++ b/test_samples/app_style/README.md
@@ -42,3 +42,20 @@ Invoke-RestMethod -Method POST -Uri "http://localhost:5199/api/sendmessage" -Con
 ```
 
 When `TOKENVALIDATION__ENABLED` is `true`, add an `Authorization: Bearer <token>` header to each call. The proactive endpoints will respond with JSON payloads describing success or validation errors.
+
+## Echo storage V2 test
+
+`echo_proactive_agent.py` selects storage with these `.env` values:
+
+```text
+STORAGE_PROVIDER=memory  # memory, blob, or cosmos
+STORAGE_VERSION=2        # 1 is the default
+```
+
+For Blob, set `BLOB_CONTAINER_ID` and optionally
+`BLOB_STORAGE_CONNECTION_STRING`. For Cosmos, set `COSMOS_ENDPOINT`,
+`COSMOS_KEY`, `COSMOS_DATABASE_ID`, and `COSMOS_CONTAINER_ID`.
+
+Send `/v2-demo` to run: missing read, create-only, duplicate create,
+conditional replace, stale replace, conditional delete, and final read. The
+sample reports each result status and cleans up its temporary key.

--- a/tests/hosting_core/state/test_agent_state.py
+++ b/tests/hosting_core/state/test_agent_state.py
@@ -16,7 +16,12 @@ from microsoft_agents.hosting.core.state.agent_state import (
 from microsoft_agents.hosting.core.state.user_state import UserState
 from microsoft_agents.hosting.core.app.state.conversation_state import ConversationState
 from microsoft_agents.hosting.core.turn_context import TurnContext
-from microsoft_agents.hosting.core.storage import Storage, StoreItem, MemoryStorage
+from microsoft_agents.hosting.core.storage import (
+    Storage,
+    StoreItem,
+    MemoryStorage,
+    StorageVersion,
+)
 from microsoft_agents.activity import (
     Activity,
     ActivityTypes,
@@ -476,6 +481,23 @@ class TestAgentState:
 
         assert storage_key in stored_data
         assert stored_data[storage_key] is not None
+
+    @pytest.mark.asyncio
+    async def test_memory_storage_v2_integration(self):
+        memory_storage = MemoryStorage(storage_version=StorageVersion.V2)
+        user_state = UserState(memory_storage)
+
+        await user_state.load(self.context)
+        property_accessor = user_state.create_property("memory_test")
+        await property_accessor.set(self.context, _MockTestDataItem("memory_value"))
+        await user_state.save(self.context)
+
+        storage_key = user_state.get_storage_key(self.context)
+        stored_data = await memory_storage.read(
+            [storage_key], target_cls=CachedAgentState
+        )
+
+        assert stored_data[storage_key].value is not None
 
     @pytest.mark.asyncio
     async def test_state_property_accessor_error_conditions(self):

--- a/tests/hosting_core/storage/test_memory_storage.py
+++ b/tests/hosting_core/storage/test_memory_storage.py
@@ -1,7 +1,29 @@
 from contextlib import asynccontextmanager
 
+import pytest
+
+from microsoft_agents.hosting.core.storage import (
+    StorageDeleteOptions,
+    StorageOperationStatus,
+    StorageVersion,
+    StorageWriteMode,
+    StorageWriteOptions,
+)
 from microsoft_agents.hosting.core.storage.memory_storage import MemoryStorage
 from tests._common.storage.utils import CRUDStorageTests
+from tests._common.storage.utils import MockStoreItem
+
+
+class _StoreItemShape:
+    def __init__(self, data=None):
+        self.data = data or {}
+
+    def store_item_to_json(self):
+        return self.data
+
+    @classmethod
+    def from_json_to_store_item(cls, data):
+        return cls(data)
 
 
 class TestMemoryStorage(CRUDStorageTests):
@@ -13,3 +35,91 @@ class TestMemoryStorage(CRUDStorageTests):
             for key, value in (initial_data or {}).items()
         }
         yield MemoryStorage(data)
+
+
+@pytest.mark.asyncio
+async def test_v2_returns_a_result_for_each_read_key():
+    storage = MemoryStorage(storage_version=StorageVersion.V2)
+    await storage.write({"existing": MockStoreItem({"value": 1})})
+
+    results = await storage.read(["existing", "missing"], target_cls=MockStoreItem)
+
+    assert results["existing"].status == StorageOperationStatus.SUCCEEDED
+    assert results["existing"].value == MockStoreItem({"value": 1})
+    assert results["existing"].version is not None
+    assert results["missing"].status == StorageOperationStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_v2_create_replace_and_conditional_delete():
+    storage = MemoryStorage(storage_version=StorageVersion.V2)
+    created = await storage.write(
+        {"key": MockStoreItem({"value": 1})},
+        StorageWriteOptions(mode=StorageWriteMode.CREATE_ONLY),
+    )
+    duplicate = await storage.write(
+        {"key": MockStoreItem({"value": 2})},
+        StorageWriteOptions(mode=StorageWriteMode.CREATE_ONLY),
+    )
+    replaced = await storage.write(
+        {"key": MockStoreItem({"value": 2})},
+        StorageWriteOptions(
+            mode=StorageWriteMode.REPLACE,
+            expected_version=created["key"].version,
+        ),
+    )
+    stale = await storage.write(
+        {"key": MockStoreItem({"value": 3})},
+        StorageWriteOptions(
+            mode=StorageWriteMode.REPLACE,
+            expected_version=created["key"].version,
+        ),
+    )
+    deleted = await storage.delete(
+        ["key"],
+        StorageDeleteOptions(expected_version=replaced["key"].version),
+    )
+
+    assert created["key"].status == StorageOperationStatus.SUCCEEDED
+    assert duplicate["key"].status == StorageOperationStatus.CONFLICT
+    assert replaced["key"].status == StorageOperationStatus.SUCCEEDED
+    assert stale["key"].status == StorageOperationStatus.CONDITION_NOT_MET
+    assert deleted["key"].status == StorageOperationStatus.SUCCEEDED
+
+
+@pytest.mark.asyncio
+async def test_v2_does_not_mutate_or_share_store_item_data():
+    storage = MemoryStorage(storage_version=StorageVersion.V2)
+    value = MockStoreItem({"nested": {"value": 1}})
+    await storage.write({"key": value})
+    value.data["nested"]["value"] = 2
+
+    first = await storage.read(["key"], target_cls=MockStoreItem)
+    first["key"].value.data["nested"]["value"] = 3
+    second = await storage.read(["key"], target_cls=MockStoreItem)
+
+    assert second["key"].value == MockStoreItem({"nested": {"value": 1}})
+
+
+@pytest.mark.asyncio
+async def test_v2_accepts_existing_store_item_shape_models():
+    storage = MemoryStorage(storage_version=StorageVersion.V2)
+
+    await storage.write({"key": _StoreItemShape({"value": 1})})
+    result = await storage.read(["key"], target_cls=_StoreItemShape)
+
+    assert result["key"].value.data == {"value": 1}
+
+
+@pytest.mark.asyncio
+async def test_v2_accepts_empty_batches_and_rejects_empty_version():
+    storage = MemoryStorage(storage_version=StorageVersion.V2)
+
+    assert await storage.read([], target_cls=MockStoreItem) == {}
+    assert await storage.write({}) == {}
+    assert await storage.delete([]) == {}
+    with pytest.raises(ValueError, match="expected_version cannot be empty"):
+        await storage.write(
+            {"key": MockStoreItem()},
+            StorageWriteOptions(expected_version=""),
+        )

--- a/tests/hosting_core/storage/test_memory_storage.py
+++ b/tests/hosting_core/storage/test_memory_storage.py
@@ -123,3 +123,21 @@ async def test_v2_accepts_empty_batches_and_rejects_empty_version():
             {"key": MockStoreItem()},
             StorageWriteOptions(expected_version=""),
         )
+
+
+@pytest.mark.asyncio
+async def test_v1_rejects_v2_options_instead_of_ignoring_them():
+    storage = MemoryStorage()
+
+    with pytest.raises(ValueError, match="write options require Storage V2"):
+        await storage.write({"key": MockStoreItem()}, StorageWriteOptions())
+    with pytest.raises(ValueError, match="delete options require Storage V2"):
+        await storage.delete(["key"], StorageDeleteOptions())
+
+
+@pytest.mark.asyncio
+async def test_v1_empty_write_reports_empty_batch():
+    storage = MemoryStorage()
+
+    with pytest.raises(ValueError, match="changes cannot be empty"):
+        await storage.write({})

--- a/tests/hosting_core/storage/test_storage_compatibility.py
+++ b/tests/hosting_core/storage/test_storage_compatibility.py
@@ -42,6 +42,15 @@ class _ModelItem(AgentsModel):
     value: str
 
 
+def test_agents_model_store_item_serialization_uses_current_instance():
+    first = _ModelItem(value="one")
+    second = _ModelItem(value="two")
+    _implement_store_item_for_agents_model_cls(first)
+
+    assert first.store_item_to_json() == {"value": "one"}
+    assert second.store_item_to_json() == {"value": "two"}
+
+
 @pytest.mark.asyncio
 async def test_v1_adapter_returns_explicit_v2_results():
     storage = _LegacyStorage()

--- a/tests/hosting_core/storage/test_storage_compatibility.py
+++ b/tests/hosting_core/storage/test_storage_compatibility.py
@@ -1,0 +1,118 @@
+import pytest
+
+from microsoft_agents.activity import AgentsModel
+from microsoft_agents.hosting.core.storage import (
+    Storage,
+    StorageDeleteOptions,
+    StorageDeleteResult,
+    StorageOperationStatus,
+    StorageReadResult,
+    StorageWriteMode,
+    StorageWriteOptions,
+)
+from microsoft_agents.hosting.core.storage.storage_compatibility import (
+    as_storage,
+    as_storage_v2,
+    assert_storage_delete_succeeded,
+    assert_storage_write_succeeded,
+    get_storage_read_value,
+)
+from microsoft_agents.hosting.core.client.conversation_id_factory import (
+    _implement_store_item_for_agents_model_cls,
+)
+from tests._common.storage.utils import MockStoreItem
+
+
+class _LegacyStorage(Storage):
+    def __init__(self):
+        self.items = {}
+
+    async def read(self, keys, *, target_cls, **kwargs):
+        return {key: self.items[key] for key in keys if key in self.items}
+
+    async def write(self, changes):
+        self.items.update(changes)
+
+    async def delete(self, keys):
+        for key in keys:
+            self.items.pop(key, None)
+
+
+class _ModelItem(AgentsModel):
+    value: str
+
+
+@pytest.mark.asyncio
+async def test_v1_adapter_returns_explicit_v2_results():
+    storage = _LegacyStorage()
+    await storage.write({"existing": MockStoreItem({"value": 1})})
+
+    results = await as_storage_v2(storage).read(
+        ["existing", "missing"], target_cls=MockStoreItem
+    )
+
+    assert results["existing"].status == StorageOperationStatus.SUCCEEDED
+    assert results["missing"].status == StorageOperationStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_v1_adapter_rejects_unsupported_conditions():
+    storage = as_storage_v2(_LegacyStorage())
+
+    with pytest.raises(NotImplementedError, match='option "mode"'):
+        await storage.write(
+            {"key": MockStoreItem()},
+            StorageWriteOptions(mode=StorageWriteMode.CREATE_ONLY),
+        )
+    with pytest.raises(NotImplementedError, match='option "expected_version"'):
+        await storage.delete(["key"], StorageDeleteOptions(expected_version="1"))
+
+
+@pytest.mark.asyncio
+async def test_v2_adapter_exposes_legacy_storage_operations():
+    legacy = _LegacyStorage()
+    v2 = as_storage_v2(legacy)
+    storage = as_storage(v2)
+
+    await storage.write({"key": MockStoreItem({"value": 1})})
+
+    assert await storage.read(["key"], target_cls=MockStoreItem) == {
+        "key": MockStoreItem({"value": 1})
+    }
+
+
+def test_result_helpers_reject_missing_or_failed_results():
+    assert (
+        get_storage_read_value(
+            {
+                "key": StorageReadResult(
+                    key="key", status=StorageOperationStatus.NOT_FOUND
+                )
+            },
+            "key",
+        )
+        is None
+    )
+    with pytest.raises(RuntimeError, match='status "missing"'):
+        assert_storage_write_succeeded({}, ["key"])
+    with pytest.raises(RuntimeError, match='status "conditionNotMet"'):
+        assert_storage_delete_succeeded(
+            {
+                "key": StorageDeleteResult(
+                    key="key", status=StorageOperationStatus.CONDITION_NOT_MET
+                )
+            },
+            ["key"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_v2_accepts_agents_model_store_item_shape():
+    value = _ModelItem(value="one")
+    _implement_store_item_for_agents_model_cls(value)
+    storage = as_storage_v2(_LegacyStorage())
+
+    await storage.write({"key": value})
+    result = await storage.read(["key"], target_cls=_ModelItem)
+
+    assert get_storage_read_value(result, "key") == value

--- a/tests/storage_blob/test_blob_storage.py
+++ b/tests/storage_blob/test_blob_storage.py
@@ -9,6 +9,7 @@ import pytest_asyncio
 from dotenv import load_dotenv
 
 from microsoft_agents.storage.blob import BlobStorage, BlobStorageConfig
+from microsoft_agents.hosting.core.storage import StorageVersion
 from azure.storage.blob.aio import BlobServiceClient, ContainerClient
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity.aio import DefaultAzureCredential
@@ -24,6 +25,16 @@ from tests._common.storage.utils import (
 # to enable blob tests, run with --run-blob
 # also, make sure that .env has:
 # TEST_BLOB_STORAGE_ACCOUNT_URL set
+
+
+def test_blob_storage_config_defaults_to_v1_and_can_select_v2():
+    assert BlobStorageConfig(container_name="test").storage_version == StorageVersion.V1
+    assert (
+        BlobStorageConfig(
+            container_name="test", storage_version=StorageVersion.V2
+        ).storage_version
+        == StorageVersion.V2
+    )
 
 
 async def reset_container(container_client: ContainerClient):

--- a/tests/storage_blob/test_blob_storage.py
+++ b/tests/storage_blob/test_blob_storage.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import gc
 import os
@@ -9,7 +10,12 @@ import pytest_asyncio
 from dotenv import load_dotenv
 
 from microsoft_agents.storage.blob import BlobStorage, BlobStorageConfig
-from microsoft_agents.hosting.core.storage import StorageVersion
+from microsoft_agents.hosting.core.storage import (
+    StorageDeleteOptions,
+    StorageOperationStatus,
+    StorageVersion,
+    StorageWriteOptions,
+)
 from azure.storage.blob.aio import BlobServiceClient, ContainerClient
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity.aio import DefaultAzureCredential
@@ -35,6 +41,106 @@ def test_blob_storage_config_defaults_to_v1_and_can_select_v2():
         ).storage_version
         == StorageVersion.V2
     )
+
+
+@pytest.mark.asyncio
+async def test_v1_rejects_v2_options_instead_of_ignoring_them():
+    storage = object.__new__(BlobStorage)
+    storage.storage_version = StorageVersion.V1
+
+    with pytest.raises(ValueError, match="write options require Storage V2"):
+        await storage.write({"key": MockStoreItem()}, StorageWriteOptions())
+    with pytest.raises(ValueError, match="delete options require Storage V2"):
+        await storage.delete(["key"], StorageDeleteOptions())
+
+
+class _ConcurrentCallBarrier:
+    def __init__(self, expected: int):
+        self._expected = expected
+        self._active = 0
+        self.max_active = 0
+        self._ready = asyncio.Event()
+
+    async def wait(self):
+        self._active += 1
+        self.max_active = max(self.max_active, self._active)
+        if self._active == self._expected:
+            self._ready.set()
+        await asyncio.wait_for(self._ready.wait(), timeout=1)
+        self._active -= 1
+
+
+class _BlobDownloader:
+    properties = {"etag": "v1"}
+
+    def __init__(self, key: str):
+        self._key = key
+
+    async def readall(self):
+        return json.dumps({"value": self._key}).encode()
+
+
+class _ConcurrentBlobClient:
+    def __init__(self, key: str, barrier: _ConcurrentCallBarrier):
+        self._key = key
+        self._barrier = barrier
+
+    async def download_blob(self, **_kwargs):
+        await self._barrier.wait()
+        return _BlobDownloader(self._key)
+
+    async def get_blob_properties(self):
+        await self._barrier.wait()
+        return {"etag": "v1"}
+
+    async def upload_blob(self, *_args, **_kwargs):
+        return {"etag": "v2"}
+
+    async def delete_blob(self, **_kwargs):
+        return None
+
+
+class _ConcurrentBlobContainer:
+    def __init__(self, barrier: _ConcurrentCallBarrier):
+        self._barrier = barrier
+
+    def get_blob_client(self, key: str):
+        return _ConcurrentBlobClient(key, self._barrier)
+
+
+def _create_v2_blob_storage(barrier: _ConcurrentCallBarrier):
+    storage = object.__new__(BlobStorage)
+    storage.storage_version = StorageVersion.V2
+    storage._initialized = True
+    storage._container_client = _ConcurrentBlobContainer(barrier)
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_v2_batches_run_independent_blob_operations_concurrently():
+    barrier = _ConcurrentCallBarrier(2)
+    storage = _create_v2_blob_storage(barrier)
+    read = await storage.read(["one", "two"], target_cls=MockStoreItem)
+    assert all(
+        result.status == StorageOperationStatus.SUCCEEDED for result in read.values()
+    )
+    assert barrier.max_active == 2
+
+    barrier = _ConcurrentCallBarrier(2)
+    storage = _create_v2_blob_storage(barrier)
+    write = await storage.write({"one": MockStoreItem(), "two": MockStoreItem()})
+    assert all(
+        result.status == StorageOperationStatus.SUCCEEDED for result in write.values()
+    )
+    assert barrier.max_active == 2
+
+    barrier = _ConcurrentCallBarrier(2)
+    storage = _create_v2_blob_storage(barrier)
+    delete = await storage.delete(["one", "two"])
+    assert all(
+        result.status == StorageOperationStatus.SUCCEEDED for result in delete.values()
+    )
+    assert barrier.max_active == 2
 
 
 async def reset_container(container_client: ContainerClient):

--- a/tests/storage_cosmos/test_cosmos_db_config.py
+++ b/tests/storage_cosmos/test_cosmos_db_config.py
@@ -2,6 +2,7 @@ import json
 import pytest
 
 from microsoft_agents.storage.cosmos import CosmosDBStorageConfig
+from microsoft_agents.hosting.core.storage import StorageVersion
 
 # thank you AI, again
 
@@ -42,6 +43,13 @@ def config_with_options():
 
 
 class TestCosmosDBStorageConfig:
+
+    def test_storage_version_defaults_to_v1_and_can_select_v2(self):
+        assert CosmosDBStorageConfig().storage_version == StorageVersion.V1
+        assert (
+            CosmosDBStorageConfig(storage_version=StorageVersion.V2).storage_version
+            == StorageVersion.V2
+        )
 
     def test_constructor_with_parameters(self):
         """Test creating config with direct parameters"""

--- a/tests/storage_cosmos/test_cosmos_db_storage.py
+++ b/tests/storage_cosmos/test_cosmos_db_storage.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import asyncio
 import os
 import gc
 from contextlib import asynccontextmanager
@@ -16,6 +17,12 @@ from azure.identity.aio import DefaultAzureCredential
 
 from microsoft_agents.storage.cosmos import CosmosDBStorage, CosmosDBStorageConfig
 from microsoft_agents.storage.cosmos.key_ops import sanitize_key
+from microsoft_agents.hosting.core.storage import (
+    StorageDeleteOptions,
+    StorageOperationStatus,
+    StorageVersion,
+    StorageWriteOptions,
+)
 
 from tests._common.storage.utils import (
     QuickCRUDStorageTests,
@@ -48,6 +55,84 @@ def create_config(compat_mode):
 @pytest.fixture
 def config():
     return create_config(compat_mode=False)
+
+
+@pytest.mark.asyncio
+async def test_v1_rejects_v2_options_instead_of_ignoring_them():
+    storage = object.__new__(CosmosDBStorage)
+    storage.storage_version = StorageVersion.V1
+
+    with pytest.raises(ValueError, match="write options require Storage V2"):
+        await storage.write({"key": MockStoreItem()}, StorageWriteOptions())
+    with pytest.raises(ValueError, match="delete options require Storage V2"):
+        await storage.delete(["key"], StorageDeleteOptions())
+
+
+class _ConcurrentCallBarrier:
+    def __init__(self, expected: int):
+        self._expected = expected
+        self._active = 0
+        self.max_active = 0
+        self._ready = asyncio.Event()
+
+    async def wait(self):
+        self._active += 1
+        self.max_active = max(self.max_active, self._active)
+        if self._active == self._expected:
+            self._ready.set()
+        await asyncio.wait_for(self._ready.wait(), timeout=1)
+        self._active -= 1
+
+
+class _ConcurrentCosmosContainer:
+    def __init__(self, barrier: _ConcurrentCallBarrier):
+        self._barrier = barrier
+
+    async def read_item(self, key, _partition_key):
+        await self._barrier.wait()
+        return {"id": key, "document": {"value": key}, "_etag": "v1"}
+
+    async def upsert_item(self, **_kwargs):
+        return {"_etag": "v2"}
+
+    async def delete_item(self, *_args, **_kwargs):
+        return None
+
+
+def _create_v2_cosmos_storage(barrier: _ConcurrentCallBarrier):
+    storage = object.__new__(CosmosDBStorage)
+    storage.storage_version = StorageVersion.V2
+    storage._container = _ConcurrentCosmosContainer(barrier)
+    storage._sanitize = lambda key: key
+    storage._get_partition_key = lambda key: key
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_v2_batches_run_independent_cosmos_operations_concurrently():
+    barrier = _ConcurrentCallBarrier(2)
+    storage = _create_v2_cosmos_storage(barrier)
+    read = await storage.read(["one", "two"], target_cls=MockStoreItem)
+    assert all(
+        result.status == StorageOperationStatus.SUCCEEDED for result in read.values()
+    )
+    assert barrier.max_active == 2
+
+    barrier = _ConcurrentCallBarrier(2)
+    storage = _create_v2_cosmos_storage(barrier)
+    write = await storage.write({"one": MockStoreItem(), "two": MockStoreItem()})
+    assert all(
+        result.status == StorageOperationStatus.SUCCEEDED for result in write.values()
+    )
+    assert barrier.max_active == 2
+
+    barrier = _ConcurrentCallBarrier(2)
+    storage = _create_v2_cosmos_storage(barrier)
+    delete = await storage.delete(["one", "two"])
+    assert all(
+        result.status == StorageOperationStatus.SUCCEEDED for result in delete.values()
+    )
+    assert barrier.max_active == 2
 
 
 async def reset_container(container_client):


### PR DESCRIPTION
Fixes #559

> [!IMPORTANT]
> This PR ports Storage V2 from [#1272](https://github.com/microsoft/Agents-for-js/pull/1272) (JS PR) using https://github.com/microsoft/Agents-for-net/pull/883 as reference.

## Description

Add Storage V2 to Python. Storage V1 remains the default and remains compatible.

## Changes

### Storage API

- Add V1 and V2 storage versions.
- Add V2 read, write, and delete result types with status and version data.
- Add create-only, replace, conditional replace, and conditional delete modes.
- Infer V1 or V2 `read()` return types from the storage constructor version.

### Storage providers

- Add Storage V2 support to Memory, Blob, and Cosmos DB storage.
- Keep V1 behavior for existing applications.
- Add compatibility helpers for state, OAuth, proactive messaging, and conversation ID flows.

### Sample and docs

- Update the app-style Echo sample for Memory, Blob, and Cosmos DB.
- Add `STORAGE_PROVIDER` and `STORAGE_VERSION` configuration.
- Add `/v2-demo` to validate V2 statuses and optimistic concurrency.
- Add a counter and `/delete` flow to validate V1 and V2 state behavior.
- Update storage documentation.

### Tests

- Add Memory Storage V2 and compatibility tests.
- Add Blob and Cosmos configuration coverage.

## Testing

- `pytest tests/hosting_core/storage tests/hosting_core/state tests/storage_blob tests/storage_cosmos -q`
  - 660 passed, 76 skipped.
- Verified Pyright inference for V1 and V2 constructors.
- Tested the Echo sample with Agents Playground, Blob emulator, and Cosmos DB emulator.

The following images show the V1 and V2 state checks for Memory, Blob, and Cosmos DB: counter progression, `/delete`, and reset to `[0]`.

<img width="1921" height="2876" alt="imagen" src="https://github.com/user-attachments/assets/6e6c57b8-102a-47f1-b7cc-697913c25d1f" />

The V2 capability checks passed for Memory, Blob, and Cosmos DB:

1. Missing read returns `notFound`.
2. Create-only returns success and a version.
3. Duplicate create returns `conflict`.
4. Read returns value and version.
5. Conditional replace returns a new version.
6. Stale replace returns `conditionNotMet`.
7. Conditional delete returns success.
8. Final read returns `notFound`.

<img width="927" height="1579" alt="imagen" src="https://github.com/user-attachments/assets/69d7871c-5d70-4d21-ba08-2c54ed8fc3a1" />
