### PR TITLE
[#535] StreamingResponse: mutating the finalized "final" stream activity (delete or update) after end_stream() re-hangs the Teams client's typing/streaming indicator

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/typing_indicator.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/app/typing_indicator.py
@@ -217,7 +217,17 @@ class TypingIndicator:
                     self._stop_loop()
                 return await next_handler()
 
+            async def _on_update_activity_handler(ctx, activity, next_handler):
+                self._stop_loop()
+                return await next_handler()
+
+            async def _on_delete_activity_handler(ctx, reference, next_handler):
+                self._stop_loop()
+                return await next_handler()
+
             self._context.on_send_activities(_on_send_activities_handler)
+            self._context.on_update_activity(_on_update_activity_handler)
+            self._context.on_delete_activity(_on_delete_activity_handler)
             self._hook_registered = True
 
     def _stop_loop(self) -> None:

--- a/tests/hosting_core/app/test_typing_indicator.py
+++ b/tests/hosting_core/app/test_typing_indicator.py
@@ -49,14 +49,17 @@ class StubTurnContext:
         self._on_update_handlers = []
         self._on_delete_handlers = []
 
-    def on_send_activities(self, handler):
-        self._on_send_handlers.append(handler)
+def on_send_activities(self, handler):
+    self._on_send_handlers.append(handler)
+    return self
 
-    def on_update_activity(self, handler):
-        self._on_update_handlers.append(handler)
+def on_update_activity(self, handler):
+    self._on_update_handlers.append(handler)
+    return self
 
-    def on_delete_activity(self, handler):
-        self._on_delete_handlers.append(handler)
+def on_delete_activity(self, handler):
+    self._on_delete_handlers.append(handler)
+    return self
 
     @property
     def sent_activities(self):

--- a/tests/hosting_core/app/test_typing_indicator.py
+++ b/tests/hosting_core/app/test_typing_indicator.py
@@ -49,17 +49,17 @@ class StubTurnContext:
         self._on_update_handlers = []
         self._on_delete_handlers = []
 
-def on_send_activities(self, handler):
-    self._on_send_handlers.append(handler)
-    return self
+    def on_send_activities(self, handler):
+        self._on_send_handlers.append(handler)
+        return self
 
-def on_update_activity(self, handler):
-    self._on_update_handlers.append(handler)
-    return self
+    def on_update_activity(self, handler):
+        self._on_update_handlers.append(handler)
+        return self
 
-def on_delete_activity(self, handler):
-    self._on_delete_handlers.append(handler)
-    return self
+    def on_delete_activity(self, handler):
+        self._on_delete_handlers.append(handler)
+        return self
 
     @property
     def sent_activities(self):

--- a/tests/hosting_core/app/test_typing_indicator.py
+++ b/tests/hosting_core/app/test_typing_indicator.py
@@ -347,20 +347,23 @@ async def test_send_hook_does_not_block_on_inflight_typing_send():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("handlers_attribute", "mutation"),
+    "handlers_attribute",
     [
-        ("_on_update_handlers", Activity(type=ActivityTypes.message)),
-        ("_on_delete_handlers", "activity-id"),
+        "_on_update_handlers",
+        "_on_delete_handlers",
     ],
 )
-async def test_mutation_hook_stops_before_initial_typing_send(
-    handlers_attribute, mutation
-):
+async def test_mutation_hook_stops_before_initial_typing_send(handlers_attribute):
     """Update and delete operations should cancel typing before the mutation."""
     context = StubTurnContext()
     opts = _fast_options(initial_delay_ms=50, interval_ms=10)
     indicator = TypingIndicator(context, typing_options=opts)
     indicator.start()
+
+    mutation = Activity(type=ActivityTypes.message)
+    if handlers_attribute == "_on_delete_handlers":
+        mutation = context.activity.get_conversation_reference()
+        mutation.activity_id = "activity-id"
 
     handlers = getattr(context, handlers_attribute)
     assert len(handlers) == 1

--- a/tests/hosting_core/app/test_typing_indicator.py
+++ b/tests/hosting_core/app/test_typing_indicator.py
@@ -46,9 +46,17 @@ class StubTurnContext:
             recipient={"id": "user"},
         )
         self._on_send_handlers = []
+        self._on_update_handlers = []
+        self._on_delete_handlers = []
 
     def on_send_activities(self, handler):
         self._on_send_handlers.append(handler)
+
+    def on_update_activity(self, handler):
+        self._on_update_handlers.append(handler)
+
+    def on_delete_activity(self, handler):
+        self._on_delete_handlers.append(handler)
 
     @property
     def sent_activities(self):
@@ -331,6 +339,44 @@ async def test_send_hook_does_not_block_on_inflight_typing_send():
     assert next_handler_called
 
     release_send.set()
+    await indicator._stop_async()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handlers_attribute", "mutation"),
+    [
+        ("_on_update_handlers", Activity(type=ActivityTypes.message)),
+        ("_on_delete_handlers", "activity-id"),
+    ],
+)
+async def test_mutation_hook_stops_before_initial_typing_send(
+    handlers_attribute, mutation
+):
+    """Update and delete operations should cancel typing before the mutation."""
+    context = StubTurnContext()
+    opts = _fast_options(initial_delay_ms=50, interval_ms=10)
+    indicator = TypingIndicator(context, typing_options=opts)
+    indicator.start()
+
+    handlers = getattr(context, handlers_attribute)
+    assert len(handlers) == 1
+
+    next_handler_called = False
+
+    async def _next_handler():
+        nonlocal next_handler_called
+        next_handler_called = True
+        return "mutation-result"
+
+    result = await handlers[0](context, mutation, _next_handler)
+    await asyncio.sleep(0.075)
+
+    assert result == "mutation-result"
+    assert next_handler_called
+    assert indicator._stopped
+    assert context.sent_activities == []
+
     await indicator._stop_async()
 
 


### PR DESCRIPTION
Fixes #535

## Description
This pull request enhances the typing indicator's behavior by ensuring it stops when update or delete activity events occur, not just when send activities are triggered. It introduces new hooks for update and delete activities, updates the stub context in tests to support these hooks, and adds new tests to verify this behavior.

**Typing indicator enhancements:**

* Added handlers in `TypingIndicator` to stop the typing indicator loop on update and delete activity events, in addition to existing send activities. (`microsoft_agents/hosting/core/app/typing_indicator.py`)

**Testing improvements:**

* Updated `StubTurnContext` in tests to support `on_update_activity` and `on_delete_activity` handlers, allowing tests to simulate these events. (`test_typing_indicator.py`)
* Added new parameterized tests to verify that update and delete operations correctly stop the typing indicator before proceeding with the mutation. (`test_typing_indicator.py`)

## Testing
Here we can see the issue being reproduced (typing indicator is showing even after the activity was updated)
<img width="1846" height="364" alt="Reproduced" src="https://github.com/user-attachments/assets/28acd3d3-7e5e-44f9-9620-4b93e9b52a19" />

And here we can see the fix applied.
<img width="1846" height="364" alt="Fixed" src="https://github.com/user-attachments/assets/7748c8e2-2844-4fb3-9bc1-db1222f6ac94" />
