### PR TITLE
Pinning Teams SDK version

### DIFF
--- a/libraries/microsoft-agents-hosting-msteams/setup.py
+++ b/libraries/microsoft-agents-hosting-msteams/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         f"microsoft-agents-hosting-core=={package_version}",
         "aiohttp>=3.11.11",
-        "microsoft-teams-api>=2.0.0,<3",
+        "microsoft-teams-api==2.0.16",
         "msgraph-sdk>=1.58.0",
     ],
 )

--- a/libraries/microsoft-agents-hosting-msteams/setup.py
+++ b/libraries/microsoft-agents-hosting-msteams/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         f"microsoft-agents-hosting-core=={package_version}",
         "aiohttp>=3.11.11",
-        "microsoft-teams-api==2.0.16",
+        "microsoft-teams-api>=2.0.16,<2.1",
         "msgraph-sdk>=1.58.0",
     ],
 )


### PR DESCRIPTION
This pull request makes a minor update to the `libraries/microsoft-agents-hosting-msteams/setup.py` file, narrowing the version range for the `microsoft-teams-api` dependency to ensure compatibility with versions >=2.0.16 but less than 2.1.