### PR TITLE
Validate activity service URL origins

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/_http_adapter_base.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/_http_adapter_base.py
@@ -22,7 +22,7 @@ from .http._http_response import HttpResponse, HttpResponseFactory
 from .message_factory import MessageFactory
 from .rest_channel_service_client_factory import RestChannelServiceClientFactory
 from .turn_context import TurnContext
-from .outbound_host_validator import OutboundHostValidator, _try_create_url
+from .outbound_host_validator import OutboundHostValidator
 
 logger = logging.getLogger(__name__)
 
@@ -187,33 +187,5 @@ class HttpAdapterBase(ChannelServiceAdapter, ABC):
                 activity.service_url,
             )
             return False
-
-        if not claims_identity:
-            return True
-
-        claims_service_url = claims_identity.get_claim_value("serviceurl")
-        if activity.service_url and claims_service_url:
-            claim_url = _try_create_url(claims_service_url)
-            activity_url = _try_create_url(activity.service_url)
-            claim_url_host = (claim_url.host or "") if claim_url else ""
-            activity_url_host = (activity_url.host or "") if activity_url else ""
-            if (
-                not claim_url
-                or not activity_url
-                or claim_url_host.casefold() != activity_url_host.casefold()
-            ):
-                if self._host_validator and self._host_validator.enabled:
-                    logger.warning(
-                        "Service URL host mismatch: %s vs %s",
-                        claim_url_host,
-                        activity_url_host,
-                    )
-                    return False
-                else:
-                    logger.warning(
-                        "Service URL host mismatch (host validator disabled): %s vs %s",
-                        claim_url_host,
-                        activity_url_host,
-                    )
 
         return True

--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/channel_service_adapter.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/channel_service_adapter.py
@@ -8,6 +8,8 @@ from http import HTTPStatus
 from typing import Awaitable, Callable, Optional, cast
 from uuid import uuid4
 
+from yarl import URL
+
 from microsoft_agents.activity import (
     Activity,
     ActivityEventNames,
@@ -35,7 +37,29 @@ from microsoft_agents.hosting.core.authorization import (
 from microsoft_agents.hosting.core.telemetry.adapter import spans
 from .channel_service_client_factory_base import ChannelServiceClientFactoryBase
 from .channel_adapter import ChannelAdapter
+from .outbound_host_validator import _try_create_url
 from .turn_context import TurnContext
+
+
+def _get_service_url_origin(service_url: object) -> tuple[str, str, int | None] | None:
+    if not isinstance(service_url, (str, URL)):
+        return None
+
+    url = _try_create_url(service_url)
+    if not isinstance(url, URL):
+        return None
+
+    try:
+        scheme = url.scheme.casefold()
+        host = url.host
+        port = url.port
+    except (UnicodeError, ValueError):
+        return None
+
+    if not url.absolute or scheme not in {"http", "https"} or not host:
+        return None
+
+    return scheme, host.casefold(), port
 
 
 class ChannelServiceAdapter(ChannelAdapter, ABC):
@@ -402,6 +426,22 @@ class ChannelServiceAdapter(ChannelAdapter, ABC):
             If the task completes successfully, then an :class:`microsoft_agents.activity.InvokeResponse` is returned;
             otherwise, `None` is returned.
         """
+        claims_service_url = claims_identity.get_claim_value(
+            AuthenticationConstants.SERVICE_URL_CLAIM
+        )
+        if activity.service_url and claims_service_url:
+            claims_origin = _get_service_url_origin(claims_service_url)
+            activity_origin = _get_service_url_origin(activity.service_url)
+            if (
+                claims_origin is None
+                or activity_origin is None
+                or claims_origin != activity_origin
+            ):
+                raise PermissionError(
+                    "Activity service URL origin does not match the authenticated "
+                    "service URL origin."
+                )
+
         scopes: list[str] = claims_identity.get_token_scope()
         outgoing_audience: str | None = None
 

--- a/tests/hosting_core/test_http_adapter_base.py
+++ b/tests/hosting_core/test_http_adapter_base.py
@@ -1,0 +1,157 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from http import HTTPStatus
+
+import pytest
+
+from microsoft_agents.activity import Activity
+from microsoft_agents.hosting.core import (
+    ChannelServiceClientFactoryBase,
+    ClaimsIdentity,
+    HttpAdapterBase,
+)
+
+
+class _ConcreteHttpAdapter(HttpAdapterBase):
+    pass
+
+
+def _make_activity(service_url: str | None) -> Activity:
+    activity = Activity(
+        type="message",
+        id="activity-1",
+        channel_id="msteams",
+        conversation={"id": "conversation-1"},
+        from_property={"id": "user-1"},
+        recipient={"id": "agent-1"},
+    )
+    if service_url is not None:
+        activity.service_url = service_url
+    return activity
+
+
+def _make_request(
+    mocker, claims_service_url: str | None, activity_service_url: str | None
+):
+    request = mocker.Mock()
+    request.method = "POST"
+    request.json = mocker.AsyncMock(
+        return_value=_make_activity(activity_service_url).model_dump(
+            by_alias=True, exclude_none=True
+        )
+    )
+    request.get_claims_identity.return_value = ClaimsIdentity(
+        claims={"serviceurl": claims_service_url} if claims_service_url else {}
+    )
+    return request
+
+
+def _make_adapter(mocker):
+    connector_client = mocker.AsyncMock()
+    user_token_client = mocker.AsyncMock()
+    factory = mocker.Mock(spec=ChannelServiceClientFactoryBase)
+    factory.create_connector_client = mocker.AsyncMock(return_value=connector_client)
+    factory.create_user_token_client = mocker.AsyncMock(return_value=user_token_client)
+    return _ConcreteHttpAdapter(channel_service_client_factory=factory), factory
+
+
+@pytest.mark.asyncio
+async def test_rejects_service_url_origin_mismatch_before_client_creation(mocker):
+    adapter, factory = _make_adapter(mocker)
+    agent = mocker.Mock()
+    agent.on_turn = mocker.AsyncMock()
+    request = _make_request(
+        mocker,
+        claims_service_url="https://trusted.example/claims-path",
+        activity_service_url="https://different.example/activity-path",
+    )
+
+    response = await adapter.process_request(request, agent)
+
+    assert response.status_code == HTTPStatus.UNAUTHORIZED
+    factory.create_user_token_client.assert_not_awaited()
+    factory.create_connector_client.assert_not_awaited()
+    agent.on_turn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_accepts_matching_service_url_origin(mocker):
+    adapter, factory = _make_adapter(mocker)
+    agent = mocker.Mock()
+    agent.on_turn = mocker.AsyncMock()
+    request = _make_request(
+        mocker,
+        claims_service_url="https://trusted.example/claims-path",
+        activity_service_url="https://trusted.example/activity-path",
+    )
+
+    response = await adapter.process_request(request, agent)
+
+    assert response.status_code == HTTPStatus.ACCEPTED
+    factory.create_user_token_client.assert_awaited_once()
+    factory.create_connector_client.assert_awaited_once()
+    agent.on_turn.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "claims_service_url, activity_service_url",
+    [
+        ("https://trusted.example/path", "http://trusted.example/path"),
+        ("https://trusted.example/path", "https://trusted.example:444/path"),
+        ("https://trusted.example/path", "https://different.example/path"),
+        ("https://trusted.example/path", "relative/path"),
+        ("https://trusted.example/path", "ftp://trusted.example/path"),
+        ("https://trusted.example/path", "https://trusted.example:invalid/path"),
+        ("not a URL", "https://trusted.example/path"),
+        (123, "https://trusted.example/path"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_process_activity_rejects_mismatched_or_invalid_origins_before_clients(
+    mocker, claims_service_url, activity_service_url
+):
+    adapter, factory = _make_adapter(mocker)
+    callback = mocker.AsyncMock()
+    claims_identity = ClaimsIdentity(claims={"serviceurl": claims_service_url})
+
+    with pytest.raises(PermissionError):
+        await adapter.process_activity(
+            claims_identity,
+            _make_activity(activity_service_url),
+            callback,
+        )
+
+    factory.create_user_token_client.assert_not_awaited()
+    factory.create_connector_client.assert_not_awaited()
+    callback.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "claims_service_url, activity_service_url",
+    [
+        ("https://trusted.example:443/claims", "https://TRUSTED.EXAMPLE/activity"),
+        ("http://trusted.example/claims", "http://trusted.example:80/activity"),
+        (None, "https://activity.example/path"),
+        ("https://trusted.example/path", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_process_activity_accepts_matching_origins_and_missing_claims(
+    mocker, claims_service_url, activity_service_url
+):
+    adapter, factory = _make_adapter(mocker)
+    callback = mocker.AsyncMock()
+    claims_identity = ClaimsIdentity(
+        claims={"serviceurl": claims_service_url} if claims_service_url else {}
+    )
+
+    await adapter.process_activity(
+        claims_identity,
+        _make_activity(activity_service_url),
+        callback,
+    )
+
+    factory.create_user_token_client.assert_awaited_once()
+    factory.create_connector_client.assert_awaited_once()
+    callback.assert_awaited_once()


### PR DESCRIPTION
## Summary
- compare authenticated and activity service URL origins at the shared activity-processing boundary
- preserve missing-claim compatibility and existing optional host allowlist behavior
- add focused HTTP and direct-processing regression coverage

## Testing
- `pytest -q tests/hosting_core` (2579 passed, 6 skipped)
- Black check on changed files
- Flake8 check on the new regression test