### PR TITLE
Removing option to specify a majority of arguments into AgentAuthConfiguration.__init__ positionally

### DIFF
--- a/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
+++ b/libraries/microsoft-agents-hosting-core/microsoft_agents/hosting/core/authorization/agent_auth_configuration.py
@@ -123,6 +123,7 @@ class AgentAuthConfiguration:
         client_id: str | None = None,
         tenant_id: str | None = None,
         client_secret: str | None = None,
+        *,
         cert_pfx_file: str | None = None,
         connection_name: str | None = None,
         federated_client_id: str | None = None,


### PR DESCRIPTION
This pull request introduces a minor change to the `AgentAuthConfiguration` class constructor to improve parameter handling. The change enforces the use of keyword-only arguments for parameters following the added `*`, which makes the API clearer and helps prevent accidental misuse.

- Constructor improvement:
  * Added a `*` in the `__init__` method signature of `agent_auth_configuration.py` to require that `cert_pfx_file`, `connection_name`, and `federated_client_id` are specified as keyword arguments.